### PR TITLE
Fixes obsid checks in check_flick_pix_mon.

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -1166,8 +1166,8 @@ sub check_flick_pix_mon {
 #############################################################################################
     my $self = shift;
 
-    # only check ERs for these MONS
-    return if ( $self->{obsid} =~ /NONE/ or $self->{obsid} < 50000 );
+    # this only applies to ERs (and they should have numeric obsids)
+    return unless ( $self->{obsid} =~ /^\d+$/ and $self->{obsid} > 50000 );
 
     my $c;
     # Check for existence of a star catalog


### PR DESCRIPTION
Stops "Argument "DC_T0" isn't numeric in numeric lt (<) at
/data/fido/newska/lib/perl/Ska/Starcheck/Obsid.pm line 1160." errors
when run in vehicle mode on products with dark cal obsids.
