### PR TITLE
Remove updating of Chex and Chex starcheck log.

### DIFF
--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -58,7 +58,6 @@ my %par = (dir  => '.',
 		   yaml => 1,
 		   config_file => "characteristics.yaml",
 		   fid_char => "fid_CHARACTERISTICS",
-		   log_file => undef,
 		   );
 
 my $agasc_parent_dir = '/proj/sot/ska/data/agasc';
@@ -78,12 +77,10 @@ GetOptions( \%par,
 			'sc_data=s',
 			'fid_char=s',
 			'config_file=s',
-			'log_file=s',
 			) ||
     exit( 1 );
 
 
-my $log_fh = defined $par{log_file} ? open_log_file($par{log_file}) : undef;
 my $Starcheck_Data = $par{sc_data} || "$ENV{SKA_DATA}/starcheck" || "$SKA/data/starcheck";
 
 my $STARCHECK   = $par{out} || ($par{vehicle} ? 'v_starcheck' : 'starcheck');
@@ -151,7 +148,7 @@ if ( defined $par{agasc} or defined $par{agasc_dir}){
     }
 }
 print STDERR "Using AGASC from $agasc_dir \n";
-print $log_fh "Using AGASC from $agasc_dir \n" if ($log_fh);
+
 
 
 my $manerr_file= get_file("$par{dir}/output/*_ManErr.txt",'manerr');    
@@ -172,14 +169,12 @@ my $ACA_badpix_firstline =  io($ACA_bad_pixel_file)->getline;
 if ($ACA_badpix_firstline =~ /Bad Pixel.*\d{7}\s+\d{7}\s+(\d{7}).*/ ){
     $ACA_badpix_date = $1;
     print STDERR "Using ACABadPixel file from $ACA_badpix_date Dark Cal \n";
-    print $log_fh "Using ACABadPixel file from $ACA_badpix_date Dark Cal \n" if ($log_fh);
 }
 
 
 unless (-e $STARCHECK) {
     die "Couldn't make directory $STARCHECK\n" unless (mkdir $STARCHECK, 0777);
     print STDERR "Created plot directory $STARCHECK\n";
-    print $log_fh "Created plot directory $STARCHECK\n" if ($log_fh);
 }
 
 # copy over the up and down gifs and overlib
@@ -982,7 +977,6 @@ sub get_file {
     } 
     $input_files{$name}=$files[0];
     print STDERR "Using $name file $files[0]\n";
-    print $log_fh "Using $name file $files[0]\n" if ($log_fh);
     return $files[0];
 }
 
@@ -1007,23 +1001,6 @@ sub warning {
     print STDERR $text;
 }
 
-##***************************************************************************
-sub open_log_file {
-##***************************************************************************
-    my $log_file = shift;
-    my $log_fh;
-
-    if ($log_fh = new IO::File ">> $log_file") {
-	my $date = `date`;
-	chomp $date;
-	print $log_fh "\nStarcheck run at $date by $ENV{USER}\n";
-	print $log_fh "DIR: $ENV{PWD}\n";
-	print $log_fh "CMD: $0 @ARGV\n\n";
-    } else {
-	warn "Couldn't open $log_file for appending\n";
-    }
-    return $log_fh;
-}
 
 ##***************************************************************************
 sub usage


### PR DESCRIPTION
Leave chex cmd line options.  Add warning if used and helptext
indicating Chex has been removed.

Add a log_file option to replace the default Chex starcheck logging.

Issue #38
