### PR TITLE
Fix OR parsing of TARGET_OFFSET

### DIFF
--- a/src/lib/Ska/Parse_CM_File.pm
+++ b/src/lib/Ska/Parse_CM_File.pm
@@ -591,10 +591,12 @@ sub OR_parse_obs {
     $obs{SS_OBJECT} = $1 if (/SS_OBJECT=([^,\)]+)/);
     $obs{SI} = $1 if (/SI=([^,]+)/);
  #   print STDERR "obsSI = $obs{SI} \n";
-    $obs{TARGET_OFFSET_Y} = $1
-        if (/TARGET_OFFSET=\((-?[\d\.]+)\)/);
-    ($obs{TARGET_OFFSET_Y}, $obs{TARGET_OFFSET_Z}) = ($1, $2)
-	if (/TARGET_OFFSET=\((-?[\d\.]+),(-?[\d\.]+)\)/);
+    if (/TARGET_OFFSET=\((-?[\d\.]+),(-?[\d\.]+)\)/){
+        ($obs{TARGET_OFFSET_Y}, $obs{TARGET_OFFSET_Z}) = ($1, $2);
+    }
+    elsif (/TARGET_OFFSET=\((-?[\d\.]+)\)/){
+        $obs{TARGET_OFFSET_Y} = $1;
+    }
     ($obs{DITHER_ON},
      $obs{DITHER_Y_AMP},$obs{DITHER_Y_FREQ}, $obs{DITHER_Y_PHASE},
      $obs{DITHER_Z_AMP},$obs{DITHER_Z_FREQ}, $obs{DITHER_Z_PHASE}) = split ',', $1


### PR DESCRIPTION
The target offset regular expression was returning results like:

TARGET_OFFSET_Z = "ROLL=(127.0"

as the regular expression was not restrictive enough for the case when
the target offset is specified as a single value and the ROLL data follows
on the same line.  I believe that the single value case is just the
TARGET_OFFSET_Y value (judging from OCAT y_det_offset lookups), so I've
broken the single value case out to its own regex.
