### PR TITLE
Fix uninitialized errors on 2014/JAN2514/oflsa

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -709,6 +709,12 @@ sub check_bright_perigee{
     my $obs_tstart = $self->{obs_tstart};
     my $obs_tstop = $self->{obs_tstop};
 
+    # if observation stop time is undefined, warn and return
+    if (not defined $obs_tstop){
+        push @{$self->{warn}}, "$alarm Perigee bright stars not being checked, no obs tstop available\n";
+	return;
+    }
+
     # is this obsid in perigee?  assume no to start
     my $in_perigee = 0;
 


### PR DESCRIPTION
Because the observation tstop is not known/set due to the replan/reopen,
the check_bright_perigee routine was throwing a

Use of uninitialized value in numeric gt (>) at src/lib/Ska/Starcheck/Obsid.pm line 719.

for every line in the radmon history.  This change just warns and exits
if the observation has no obs_tstop.
