### PR TITLE
RDE obsids are not all Special Case ERs

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -780,15 +780,19 @@ sub check_for_special_case_er{
         and $self->{prev}->{obsid} =~ /^\d+$/
         and $self->{prev}->{obsid} < 40000
         and $self->{prev}->find_command("MP_STARCAT")
-        and $self->{obs_tstop} - $self->{obs_tstart} < 10*60
         and abs($self->{ra} - $self->{prev}->{ra}) < 0.001
         and abs($self->{dec} - $self->{prev}->{dec}) < 0.001
         and abs($self->{roll} - $self->{prev}->{roll}) < 0.001){
-      $self->{special_case_er} = 1;
-      push @{$self->{fyi}}, "$info Special Case ER";
+        if (($self->{obs_tstop} - $self->{obs_tstart}) < 10*60){
+            $self->{special_case_er} = 1;
+            push @{$self->{fyi}}, "$info Special Case ER\n";
+        }
+        else{
+            push @{$self->{fyi}},
+            sprintf("$info Same attitude as last obsid but too long (%.1f min) for Special Case ER\n", ($self->{obs_tstop} - $self->{obs_tstart})/60.);
+        }
     }
 }
-
 
 #############################################################################################
 sub check_sim_position {


### PR DESCRIPTION
In:

https://icxc.harvard.edu/mp/mplogs/2012/OCT1512/oflsa/starcheck.html

54235 is handled as a "Special Case ER" and 54229 is not.  Should 54229 be handled as a Special Case ER even though it doesn't satisfy the "NPM <= 10 min" criterion?  Should starcheck mention that it has the same attitude as the previous OR but is longer than 10 minutes?  Or should ERs with RDE oflsids be handled as "Special Case ERs" even if they don't satisfy the <= 10 minutes?
