### PR TITLE
User gets unsupported matplotlib backend.

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -22,8 +22,7 @@ import yaml
 # Matplotlib setup
 # Use Agg backend for command-line (non-interactive) operation
 import matplotlib
-if __name__ == '__main__':
-    matplotlib.use('Agg')
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 import Ska.Matplotlib


### PR DESCRIPTION
It looks like the code to select the 'Agg' backend for non-interactive use

https://github.com/sot/starcheck/blob/master/starcheck/calc_ccd_temps.py#L26

doesn't get hit in the standard use case (just importing get_ccd_temps), so a user-specified or default interactive backend is set.  SOT MP seems to get GTKAgg which breaks with

```
ERROR: exceptions.RuntimeError: Cannot get window extent w/o renderer at line 14
```
