### PR TITLE
Compatibility fixes for more modern Perl (5.18)

### DIFF
--- a/src/lib/Ska/Starcheck/Dark_Cal_Checker.pm
+++ b/src/lib/Ska/Starcheck/Dark_Cal_Checker.pm
@@ -1859,7 +1859,7 @@ sub matches_entry{
     }
 
     my $REL_TIME_TOL = 1e-6; # seconds
-    my $step_rel_time_match = (($entry1->step_rel_time_replica() - $entry2->step_rel_time_replica()) < $REL_TIME_TOL);
+    my $step_rel_time_match = (abs($entry1->step_rel_time_replica() - $entry2->step_rel_time_replica()) < $REL_TIME_TOL);
     if ( !$step_rel_time_match ){
 #	push @{$output{error}} ,sprintf($entry1->datestamp() . "\t" . $entry1->comm_mnem() . "\t" . $entry1->comm_desc());
 #	push @{$output{error}}, sprintf("step relative time mismatch: " . $entry1->step_rel_time_replica() . " secs tlr, " . $entry2->step_rel_time_replica() . " secs template ");
@@ -1896,7 +1896,7 @@ sub matches_entry{
 	push @{$output{info}}, @{$hex_equal->{info}};
     }
     if (($entry1->comm_mnem() eq $entry2->comm_mnem()) and
-	(($entry1->step_rel_time_replica() - $entry2->step_rel_time_replica()) < $REL_TIME_TOL) and
+	($step_rel_time_match) and
 	($hex_equal->{status})){
 	$output{status} = 1;
     }


### PR DESCRIPTION
This PR includes minor Perl tweaks to allow starcheck to work with a more modern Perl.  These changes include (so far).
- Explicitly place parens around qw() lists as needed (required as of Perl 5.14)
- Update time checks in the dark current checker to use a numeric tolerance instead of relying on equality (this is required if we officially deprecate the hack code of date2time and use Chandra::Time everywhere).

With these changes (plus an updated Ska::Convert (date2time) package, an updated Ska.Matplotlib, and an updated xija) the current starcheck regression tests pass acceptably with a 64 bit conda skare.
