### PR TITLE
Change not enough bright stars in perigee to info statement for special case ERs

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -732,8 +732,15 @@ sub check_bright_perigee{
                               and ($c->{"GS_MAG$_"} < $min_mag) } (0 .. 16);
     my $bright_count = scalar(@bright_stars);
     if ($bright_count < $min_n_stars){
-      push @{$self->{warn}}, "$alarm $bright_count star(s) brighter than $min_mag mag. "
-      . "Perigee requires at least $min_n_stars\n";
+        if ($self->{special_case_er} == 1){
+            push @{$self->{fyi}}, "$info Only $bright_count star(s) brighter than $min_mag mag. "
+                . "Acceptable for Special Case ER\n";
+        }
+        else{
+            push @{$self->{warn}}, "$alarm $bright_count star(s) brighter than $min_mag mag. "
+                . "Perigee requires at least $min_n_stars\n";
+        }
+
     }
 }
 

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -596,10 +596,10 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->check_flick_pix_mon();
     $obs{$obsid}->check_star_catalog($or{$obsid}, $par{vehicle});
     $obs{$obsid}->check_sim_position(@sim_trans) unless $par{vehicle};
-    $obs{$obsid}->check_bright_perigee($radmon);
     $obs{$obsid}->check_dither($dither);
 	$obs{$obsid}->check_momentum_unload(\@bs);
     $obs{$obsid}->check_for_special_case_er();
+    $obs{$obsid}->check_bright_perigee($radmon);
     $obs{$obsid}->count_good_stars();
     $obs{$obsid}->make_figure_of_merit();
 # Make sure there is only one star catalog per obsid


### PR DESCRIPTION
Special case ERs should not get the "too few bright stars in perigee" warning.
Change to info statement.