### PR TITLE
Flag non-standard dither and apply monitor window checks as needed

### DIFF
--- a/src/lib/Ska/Parse_CM_File.pm
+++ b/src/lib/Ska/Parse_CM_File.pm
@@ -143,7 +143,9 @@ sub dither {
 		      ampl_p => $dither_ampl_p,
 		      ampl_y => $dither_ampl_y,
                       period_p => $dither_period_p,
-                      period_y => $dither_period_y};
+                      period_y => $dither_period_y,
+                      tlmsid => $params[$_]->{TLMSID},
+                  };
   }
     return ($dither_time_violation, \@dither);
 }

--- a/src/lib/Ska/Parse_CM_File.pm
+++ b/src/lib/Ska/Parse_CM_File.pm
@@ -122,14 +122,20 @@ sub dither {
     my $bs_start = $bs_arr->[0]->{time};
     my $r2a = 3600. * 180. / 3.14159265;
     my $pi = 3.14159265;
+
+    my $dither_state;
+    my $dither_ampl_p;
+    my $dither_ampl_y;
+    my $dither_period_p;
+    my $dither_period_y;
  
     foreach (0 .. $#state) {
-      my $dither_state = $state[$_] if defined $state[$_];
-      my $dither_ampl_p = $params[$_]->{COEFP} * $r2a if defined $params[$_]->{COEFP};
-      my $dither_ampl_y = $params[$_]->{COEFY} * $r2a if defined $params[$_]->{COEFY};
-      my $dither_period_p = 1 / ($params[$_]->{RATEP} / (2 * $pi))
+      $dither_state = $state[$_] if defined $state[$_];
+      $dither_ampl_p = $params[$_]->{COEFP} * $r2a if defined $params[$_]->{COEFP};
+      $dither_ampl_y = $params[$_]->{COEFY} * $r2a if defined $params[$_]->{COEFY};
+      $dither_period_p = 1 / ($params[$_]->{RATEP} / (2 * $pi))
          if defined $params[$_]->{RATEP};
-      my $dither_period_y = 1 / ($params[$_]->{RATEY} / (2 * $pi))
+      $dither_period_y = 1 / ($params[$_]->{RATEY} / (2 * $pi))
          if defined $params[$_]->{RATEP};
       push @dither, { time => $time[$_],
 		      state => $dither_state,

--- a/src/lib/Ska/Parse_CM_File.pm
+++ b/src/lib/Ska/Parse_CM_File.pm
@@ -119,23 +119,26 @@ sub dither {
     # Now make an array of hashes as the final output.  Keep track of where the info
     # came from to assist in debugging.
     my @dither;
-    my $dither_state;
-    my $dither_ampl_p;
-    my $dither_ampl_y;
     my $bs_start = $bs_arr->[0]->{time};
     my $r2a = 3600. * 180. / 3.14159265;
+    my $pi = 3.14159265;
  
     foreach (0 .. $#state) {
-      $dither_state = $state[$_] if defined $state[$_];
-      $dither_ampl_p = $params[$_]->{COEFP} * $r2a if defined $params[$_]->{COEFP};
-      $dither_ampl_y = $params[$_]->{COEFY} * $r2a if defined $params[$_]->{COEFY};
-      
+      my $dither_state = $state[$_] if defined $state[$_];
+      my $dither_ampl_p = $params[$_]->{COEFP} * $r2a if defined $params[$_]->{COEFP};
+      my $dither_ampl_y = $params[$_]->{COEFY} * $r2a if defined $params[$_]->{COEFY};
+      my $dither_period_p = 1 / ($params[$_]->{RATEP} / (2 * $pi))
+         if defined $params[$_]->{RATEP};
+      my $dither_period_y = 1 / ($params[$_]->{RATEY} / (2 * $pi))
+         if defined $params[$_]->{RATEP};
       push @dither, { time => $time[$_],
 		      state => $dither_state,
 		      source => $time[$_] < $bs_start ? 'history' : 'backstop',
 		      ampl_p => $dither_ampl_p,
-		      ampl_y => $dither_ampl_y};
-    }
+		      ampl_y => $dither_ampl_y,
+                      period_p => $dither_period_p,
+                      period_y => $dither_period_y};
+  }
     return ($dither_time_violation, \@dither);
 }
 

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -610,7 +610,6 @@ sub check_dither {
     my $self = shift;
 
     my $dthr = shift;		  # Ref to array of hashes containing dither states
-    my $backstop = shift;
     my %dthr_cmd = (ON => 'ENAB',   # Translation from OR terminology to dither state term.
 		    OFF => 'DISA');
 

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -624,6 +624,10 @@ sub check_dither {
     if ( $self->{obsid} =~ /^\d*$/){
 	return if ($self->{obsid} > 50000); # For eng obs, don't have OR to specify dither
     }
+    # If there's no starcat on purpose, return
+    if (defined $self->{ok_no_starcat} and $self->{ok_no_starcat}){
+        return;
+    }
     unless ($manvr = find_command($self, "MP_TARGQUAT", -1)
             and defined $manvr->{tstart}) {
 	push @{$self->{warn}}, "$alarm Dither status not checked\n";

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -760,10 +760,11 @@ sub large_dither_checks {
     my $all_dither = shift;
     my $time_tol = 10;         # Commands must be within $time_tol of expectation
 
-    # Correct times in the maneuver summary by 10 seconds
-    my $manvr_sum_offset = 10;
-    my $obs_tstart = $self->{obs_tstart} - $manvr_sum_offset;
-    my $obs_tstop = $self->{obs_tstop} - $manvr_sum_offset;
+    # The obs tstart and tstop times are derived from the OFLS maneuver summary file,
+    # which for implementation reasons gives the maneuver times offset by 10 seconds
+    # from the actual command timing. Fix this here.
+    my $obs_tstart = $self->{obs_tstart} - 10;
+    my $obs_tstop = $self->{obs_tstop} - 10;
 
     # Now check in backstop commands for :
     #  Dither is disabled (AODSDITH) 1 min prior to the end of the maneuver (EOM)

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -683,18 +683,20 @@ sub check_dither {
         }
     }
 
-
+    # Loop again to check for dither changes during the observation
+    # ACA-003
     if (not defined $obs_tstop ){
         push @{$self->{warn}},
             "$alarm Unable to determine obs tstop; could not check for dither changes during obs\n";
     }
     else{
-        # Loop again to check for dither changes during the observation
-        # ACA-003
-        foreach my $dither (@{$dthr}) {
+        foreach my $dither (reverse @{$dthr}) {
             if ($dither->{time} > ($obs_tstart + $obs_beg_pad)
                     && $dither->{time} <= $obs_tstop - $obs_end_pad) {
                 push @{$self->{warn}}, "$alarm Dither commanding at $dither->{time}.  During observation.\n";
+            }
+            if ($dither->{time} < $obs_tstart){
+                last;
             }
         }
     }

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -676,20 +676,18 @@ sub check_dither {
                       $self->large_dither_checks($backstop, $dthr);
                   }
               }
-              else{
-                  if (defined $dither->{period_y}
+              if (defined $dither->{period_y}
                       and defined $dither->{period_p}
-                      and $dither->{source} == 'backstop'){
-                      my $y_period = $dither->{period_y};
-                      my $z_period = $dither->{period_p};
-                      my $standard_y_period = $standard_y_dither{int($y_amp + .5)};
-                      my $standard_z_period = $standard_z_dither{int($z_amp + .5)};
-                      # Explicitly confirm that the dither period is within 10 seconds of the
-                      # expected dither period used with this amplitude
-                      if ((abs($y_period - $standard_y_period) > 10)
+                          and $dither->{source} eq 'backstop'){
+                  my $y_period = $dither->{period_y};
+                  my $z_period = $dither->{period_p};
+                  my $standard_y_period = $standard_y_dither{int($y_amp + .5)};
+                  my $standard_z_period = $standard_z_dither{int($z_amp + .5)};
+                  # Explicitly confirm that the dither period is within 10 seconds of the
+                  # expected dither period used with this amplitude
+                  if ((abs($y_period - $standard_y_period) > 10)
                           or (abs($z_period - $standard_z_period) > 10)){
-                          push @{$self->{yellow_warn}}, "$alarm Non-standard dither period\n";
-                      }
+                      push @{$self->{yellow_warn}}, "$alarm Non-standard dither period\n";
                   }
               }
             }

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -773,18 +773,27 @@ sub large_dither_checks {
             sprintf("$alarm Dither should be disabled 1 min before obs start for Large Dither\n");
     }
 
-    # Are parameters set to normal values 5 minutes before the end of the observation?
+
+    # Find the dither state at the end of the observation
     my $obs_stop_dither;
     foreach my $dither (reverse @{$all_dither}) {
-	if ($self->{obs_tstop} - 300 >= $dither->{time}) {
+	if ($self->{obs_tstop} >= $dither->{time}) {
             $obs_stop_dither = $dither;
             last;
         }
     }
+    # Check that the dither state at the end of the observation started 5 minutes before
+    # the end (within time_tol)
+    if ((abs($self->{obs_tstop} - $obs_stop_dither->{time} - 300) > $time_tol)){
+        push @{$self->{warn}},
+            sprintf("$alarm Last dither state for Large Dither should start 5 minutes before obs end.\n");
+    }
+    # Check that the dither state at the end of the observation is standard
     if (not standard_dither($obs_stop_dither)){
         push @{$self->{warn}},
-            sprintf("$alarm Dither parameters not set to standard values 5 minutes before obs end\n");
+            sprintf("$alarm Dither parameters not set to standard values before obs end\n");
     }
+
 }
 
 

--- a/src/run_regress
+++ b/src/run_regress
@@ -235,6 +235,7 @@ for load in \
     2011/DEC1211/oflsa \
     2012/JAN3012/oflsa \
     2013/JUL2913/oflsa \
+    2014/JAN2514/oflsa \
     2015/JAN1215/oflsb \
     2015/FEB2315/oflsa
 do

--- a/src/run_regress
+++ b/src/run_regress
@@ -237,7 +237,8 @@ for load in \
     2013/JUL2913/oflsa \
     2014/JAN2514/oflsa \
     2015/JAN1215/oflsb \
-    2015/FEB2315/oflsa
+    2015/FEB2315/oflsa \
+    2015/FEB2315/oflsb
 do
   RunRegression 1p6 fid_CHARACTERIS_FEB07
 done

--- a/src/run_regress
+++ b/src/run_regress
@@ -234,7 +234,9 @@ for load in \
     2011/APR0411/oflsa \
     2011/DEC1211/oflsa \
     2012/JAN3012/oflsa \
-    2013/JUL2913/oflsa
+    2013/JUL2913/oflsa \
+    2015/JAN1215/oflsb \
+    2015/FEB2315/oflsa
 do
   RunRegression 1p6 fid_CHARACTERIS_FEB07
 done

--- a/src/run_regress
+++ b/src/run_regress
@@ -237,8 +237,8 @@ for load in \
     2013/JUL2913/oflsa \
     2014/JAN2514/oflsa \
     2015/JAN1215/oflsb \
-    2015/FEB2315/oflsa \
-    2015/FEB2315/oflsb
+    2015/DEC1115/oflsa \
+    2015/DEC1115/oflsb
 do
   RunRegression 1p6 fid_CHARACTERIS_FEB07
 done

--- a/test_regress/test/2005/AUG2705/oflsb/starcheck.txt
+++ b/test_regress/test/2005/AUG2705/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: AUG2705B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2005/AUG2705/oflsb/CR239_1405.tlr 
 Using DOT file /data/mpcrit1/mplogs/2005/AUG2705/oflsb//mps/md239_1402.dot 

--- a/test_regress/test/2005/JUL1105/oflsc/starcheck.txt
+++ b/test_regress/test/2005/JUL1105/oflsc/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JUL1105C
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2005/JUL1105/oflsc/CR191_0806.tlr 
 Using DOT file /data/mpcrit1/mplogs/2005/JUL1105/oflsc//mps/md191_0816.dot 

--- a/test_regress/test/2005/MAR0705/oflsb/starcheck.txt
+++ b/test_regress/test/2005/MAR0705/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: MAR0705B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2005/MAR0705/oflsb/CR066_0402.tlr 
 Using DOT file /data/mpcrit1/mplogs/2005/MAR0705/oflsb//mps/md066_0408.dot 

--- a/test_regress/test/2005/NOV0705/oflsb/starcheck.txt
+++ b/test_regress/test/2005/NOV0705/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: NOV0705B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2005/NOV0705/oflsb/CR311_0601.tlr 
 Using DOT file /data/mpcrit1/mplogs/2005/NOV0705/oflsb//mps/md311_0613.dot 

--- a/test_regress/test/2006/AUG0706/oflsb/starcheck.txt
+++ b/test_regress/test/2006/AUG0706/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: AUG0706B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2006/AUG0706/oflsb/CR219_1103.tlr 
 Using DOT file /data/mpcrit1/mplogs/2006/AUG0706/oflsb//mps/md219_1104.dot 

--- a/test_regress/test/2006/DEC2506/oflsc/starcheck.txt
+++ b/test_regress/test/2006/DEC2506/oflsc/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: DEC2506C
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2006/DEC2506/oflsc/CR359_0909.tlr 
 Using DOT file /data/mpcrit1/mplogs/2006/DEC2506/oflsc//mps/md359_0921.dot 

--- a/test_regress/test/2006/MAR0606/oflsc/starcheck.txt
+++ b/test_regress/test/2006/MAR0606/oflsc/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: MAR0606C
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2006/MAR0606/oflsc/CR064_0707.tlr 
 Using DOT file /data/mpcrit1/mplogs/2006/MAR0606/oflsc//mps/md064_0716.dot 

--- a/test_regress/test/2006/NOV2006/oflsb/starcheck.txt
+++ b/test_regress/test/2006/NOV2006/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: NOV2006B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2006/NOV2006/oflsb/CR323_1207.tlr 
 Using DOT file /data/mpcrit1/mplogs/2006/NOV2006/oflsb//mps/md323_1204.dot 

--- a/test_regress/test/2007/AUG0607/oflsa/starcheck.txt
+++ b/test_regress/test/2007/AUG0607/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: AUG0607A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2007/AUG0607/oflsa/CR217_1504.tlr 
 Using DOT file /data/mpcrit1/mplogs/2007/AUG0607/oflsa//mps/md217_1505.dot 

--- a/test_regress/test/2007/AUG1407/oflsa/starcheck.txt
+++ b/test_regress/test/2007/AUG1407/oflsa/starcheck.txt
@@ -131,9 +131,9 @@ MP_STARCAT at 2007:224:17:13:55.663 (VCDU count = 15399435)
 >> WARNING: [ 1] Magnitude.   0.000
 >> WARNING: [ 2] Magnitude.   0.000
 >> WARNING: [ 3] Magnitude.   0.000
->> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Dither status not checked
 >> WARNING: Momentum Unloads not checked.
+>> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Did not find match in MAN summary for MP_TARGQUAT at 2007:224:17:13:54.020
 >> WARNING: [10] Search spoiler.  747253232: Y,Z,Radial,Mag seps:   5 193 193 -0.6
 >> WARNING: [10] Search spoiler.  747253784: Y,Z,Radial,Mag seps:   6 194 194 -0.9
@@ -179,9 +179,9 @@ MP_STARCAT at 2007:224:20:33:58.922 (VCDU count = 15446277)
 >> WARNING: [ 2] Magnitude.   0.000
 >> WARNING: [ 3] Magnitude.   0.000
 >> WARNING: [ 4] Search Box Size. Search Box smaller than slew error 
->> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Dither status not checked
 >> WARNING: Momentum Unloads not checked.
+>> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Did not find match in MAN summary for MP_TARGQUAT at 2007:224:20:33:57.279
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-9.507	-7.387	-5.471	
@@ -224,9 +224,9 @@ MP_STARCAT at 2007:224:22:23:40.556 (VCDU count = 15471961)
 >> WARNING: [ 2] Magnitude.   0.000
 >> WARNING: [ 3] Magnitude.   0.000
 >> WARNING: [ 6] Search Box Size. Search Box smaller than slew error 
->> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Dither status not checked
 >> WARNING: Momentum Unloads not checked.
+>> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Did not find match in MAN summary for MP_TARGQUAT at 2007:224:22:23:38.913
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.696	-6.643	-4.806	
@@ -270,9 +270,9 @@ MP_STARCAT at 2007:224:23:35:00.556 (VCDU count = 15488664)
 >> WARNING: [ 2] Magnitude.   0.000
 >> WARNING: [ 3] Magnitude.   0.000
 >> WARNING: [12] Search spoiler.  670564368: Y,Z,Radial,Mag seps: 229 103 251  0.8
->> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Dither status not checked
 >> WARNING: Momentum Unloads not checked.
+>> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Did not find match in MAN summary for MP_TARGQUAT at 2007:224:23:34:58.913
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-7.934	-6.003	-4.302	
@@ -311,9 +311,9 @@ MP_STARCAT at 2007:225:10:40:33.637 (VCDU count = 15644500)
 >> WARNING: [ 3] Search Box Size. Search Box smaller than slew error 
 >> WARNING: [ 4] Search Box Size. Search Box smaller than slew error 
 >> WARNING: [ 4] Search spoiler. 1041774104: Y,Z,Radial,Mag seps:  61 149 161  0.4
->> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Dither status not checked
 >> WARNING: Momentum Unloads not checked.
+>> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Did not find match in MAN summary for MP_TARGQUAT at 2007:225:10:40:31.994
 >> WARNING: [ 3] Search spoiler. 1041774584: Y,Z,Radial,Mag seps:  61 149 161 -0.4
 
@@ -352,9 +352,9 @@ MP_STARCAT at 2007:225:12:59:16.015 (VCDU count = 15676978)
 >> WARNING: Using -14 (planning limit) for t_ccd for mag limits
 >> WARNING: [ 1] Search spoiler. 1048446792: Y,Z,Radial,Mag seps: 206 100 229  2.0
 >> WARNING: [ 1] Search spoiler. 1048457496: Y,Z,Radial,Mag seps: 214 101 237  0.7
->> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Dither status not checked
 >> WARNING: Momentum Unloads not checked.
+>> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Did not find match in MAN summary for MP_TARGQUAT at 2007:225:12:59:14.372
 >> WARNING: [ 1] Search spoiler. 1048457520: Y,Z,Radial,Mag seps: 198 102 222 -0.8
 >> WARNING: [ 2] Search spoiler. 1048445736: Y,Z,Radial,Mag seps:  11 225 226 -0.5
@@ -392,8 +392,8 @@ MP_STARCAT at 2007:225:22:43:11.448 (VCDU count = 15813701)
 >> WARNING: [ 2] Search Box Size. Search Box smaller than slew error 
 >> WARNING: [ 6] Search Box Size. Search Box smaller than slew error 
 >> WARNING: [ 9] Magnitude.   5.926
->> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Dither status not checked
+>> WARNING: Perigee bright stars not being checked, no rad zone info available
 >> WARNING: Did not find match in MAN summary for MP_TARGQUAT at 2007:225:22:43:09.805
 >> WARNING: [ 5] Search spoiler.  839388784: Y,Z,Radial,Mag seps: 125  96 158 -0.9
 

--- a/test_regress/test/2007/DEC1007/oflsb/starcheck.txt
+++ b/test_regress/test/2007/DEC1007/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: DEC1007B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2007/DEC1007/oflsb/CR343_2309.tlr 
 Using DOT file /data/mpcrit1/mplogs/2007/DEC1007/oflsb//mps/md343_2316.dot 

--- a/test_regress/test/2007/MAR0507/oflsa/starcheck.txt
+++ b/test_regress/test/2007/MAR0507/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: MAR0507A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2007/MAR0507/oflsa/CR064_0600.tlr 
 Using DOT file /data/mpcrit1/mplogs/2007/MAR0507/oflsa//mps/md064_0615.dot 

--- a/test_regress/test/2007/SEP0307/oflsa/starcheck.txt
+++ b/test_regress/test/2007/SEP0307/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: SEP0307A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2007/SEP0307/oflsa/CR246_0101.tlr 
 Using DOT file /data/mpcrit1/mplogs/2007/SEP0307/oflsa//mps/md246_0109.dot 

--- a/test_regress/test/2008/JUL0708/oflsb/starcheck.txt
+++ b/test_regress/test/2008/JUL0708/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JUL0708B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2008/JUL0708/oflsb/CR188_1104.tlr 
 Using DOT file /data/mpcrit1/mplogs/2008/JUL0708/oflsb//mps/md188_1108.dot 

--- a/test_regress/test/2008/SEP2908/oflsb/starcheck.txt
+++ b/test_regress/test/2008/SEP2908/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: SEP2908B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2008/SEP2908/oflsb/CR273_0202.tlr 
 Using DOT file /data/mpcrit1/mplogs/2008/SEP2908/oflsb//mps/md273_0204.dot 

--- a/test_regress/test/2009/APR2009/oflsc/starcheck.txt
+++ b/test_regress/test/2009/APR2009/oflsc/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: APR2009C
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2009/APR2009/oflsc/CR110_0104.tlr 
 Using DOT file /data/mpcrit1/mplogs/2009/APR2009/oflsc//mps/md110_0107.dot 
@@ -79,7 +81,7 @@ Transponder B	before 2009:113:08:40:38.307
 OBSID = 10900 at 2009:110:01:28:52.721   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
 OBSID = 10901 at 2009:110:06:28:55.417   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
 OBSID = 10898 at 2009:110:11:02:27.417   8 clean ACQ | 5 clean GUI | 
-OBSID = 57166 at 2009:110:15:54:28.137   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
+OBSID = 57166 at 2009:110:15:54:28.137   8 clean ACQ | 7 clean GUI | WARNINGS [ 1]
 OBSID = 57165 at 2009:110:16:04:58.347   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 57164 at 2009:110:16:44:33.502   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
 OBSID = 57163 at 2009:111:00:45:13.705   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
@@ -93,7 +95,7 @@ OBSID = 10599 at 2009:112:13:05:17.393   7 clean ACQ | 5 clean GUI | WARNINGS [ 
          ------  2009:112:21:49:58.993   OBC Load Segment Begins     CL112:2104 
 OBSID = 10899 at 2009:112:21:53:04.993   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
 OBSID = 10348 at 2009:113:02:39:22.709   5 clean ACQ | 4 clean GUI | WARNINGS [ 4]
-OBSID = 57161 at 2009:113:07:23:09.422   5 clean ACQ | 5 clean GUI | WARNINGS [ 1] WARNINGS [ 5]
+OBSID = 57161 at 2009:113:07:23:09.422   5 clean ACQ | 5 clean GUI | WARNINGS [ 5]
 OBSID = 57160 at 2009:113:07:33:15.856   7 clean ACQ | 7 clean GUI | WARNINGS [ 2] 
 OBSID = 57159 at 2009:113:08:10:44.307   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 57158 at 2009:113:08:34:38.307   0 clean ACQ | 0 clean GUI | 
@@ -236,9 +238,9 @@ MP_STARCAT at 2009:110:15:54:28.137 (VCDU count = 834616)
 [ 8]  7   262408104   GUI  8x8     ---  10.306  11.812  -2093   -924   1   1   25    g3    
 [ 9]  7   262409384   ACQ  8x8   0.950  10.144  11.656     60   -230  14   1   90    a2    
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 8] Magnitude.  10.306
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.320	-6.359	-4.616	
 Acquisition Stars Expected  : 7.78
@@ -628,13 +630,13 @@ MP_STARCAT at 2009:113:07:23:09.422 (VCDU count = 1726406)
 [ 8]  7   658769192   GUI  8x8     ---  10.576  12.078   1369  -1798   1   1   25    g4    
 [ 9]  7   658772584   ACQ  8x8   0.511  10.509  12.078   1319   2106  20   1  120    a3   C
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 1] Magnitude.  10.307
 >> WARNING: [ 4] Magnitude.  10.461
 >> WARNING: [ 8] Magnitude.  10.576
 >> WARNING: [ 9] Marginal star. B-V = 1.500, Mag_Err = 0.45, Pos_Err = 0.06
 >> WARNING: [ 9] Magnitude.  10.509
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-5.806	-4.147	-2.756	
 Acquisition Stars Expected  : 7.14

--- a/test_regress/test/2009/FEB1609/oflsa/starcheck.txt
+++ b/test_regress/test/2009/FEB1609/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: FEB1609A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2009/FEB1609/oflsa/CR047_0600.tlr 
 Using DOT file /data/mpcrit1/mplogs/2009/FEB1609/oflsa//mps/md047_0605.dot 
@@ -86,7 +88,7 @@ OBSID = 10651 at 2009:048:07:34:40.315   8 clean ACQ | 5 clean GUI |
 OBSID = 10743 at 2009:048:10:14:56.315   8 clean ACQ | 5 clean GUI | 
          ------  2009:048:20:25:00.000   OBC Load Segment Begins     CL048:2000 
 OBSID =  8582 at 2009:049:13:16:55.882   6 clean ACQ | 5 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
-OBSID = 57295 at 2009:049:20:11:45.581   6 clean ACQ | 6 clean GUI | WARNINGS [ 3] WARNINGS [ 1]
+OBSID = 57295 at 2009:049:20:11:45.581   6 clean ACQ | 6 clean GUI | WARNINGS [ 2] WARNINGS [ 1]
 OBSID = 57294 at 2009:049:20:22:15.791   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 57293 at 2009:049:23:33:37.079   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
          ------  2009:050:02:45:00.000   OBC Load Segment Begins     CL050:0200 
@@ -431,9 +433,9 @@ MP_STARCAT at 2009:049:20:11:45.581 (VCDU count = 13881878)
 
 >> WARNING: [ 8] Magnitude.  10.683
 >> WARNING: [ 9] Magnitude.  10.637
->> WARNING: 0 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 1] Marginal star. B-V = 1.500, Mag_Err = 0.50, Pos_Err = 0.12
 >> INFO   : Special Case ER
+>> INFO   : Only 0 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-6.417	-4.700	-3.227	
 Acquisition Stars Expected  : 7.44

--- a/test_regress/test/2009/JUL0609/oflsb/starcheck.txt
+++ b/test_regress/test/2009/JUL0609/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JUL0609B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2009/JUL0609/oflsb/CR186_1602.tlr 
 Using DOT file /data/mpcrit1/mplogs/2009/JUL0609/oflsb//mps/md186_1602.dot 
@@ -79,7 +81,7 @@ Transponder B	before 2009:190:01:14:41.674
 OBSID = 10264 at 2009:186:16:37:13.822   8 clean ACQ | 5 clean GUI | 
 OBSID = 56991 at 2009:186:18:28:33.822   8 clean ACQ | 7 clean GUI | WARNINGS [ 1]
 OBSID = 10460 at 2009:186:18:51:44.542   8 clean ACQ | 5 clean GUI | 
-OBSID = 56990 at 2009:187:07:42:58.619   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
+OBSID = 56990 at 2009:187:07:42:58.619   8 clean ACQ | 8 clean GUI | 
 OBSID = 56989 at 2009:187:07:53:05.053   8 clean ACQ | 8 clean GUI | 
 OBSID = 56988 at 2009:187:09:12:24.551   8 clean ACQ | 8 clean GUI | 
 OBSID = 56987 at 2009:187:19:37:46.053   8 clean ACQ | 8 clean GUI | 
@@ -96,7 +98,7 @@ OBSID = 10259 at 2009:189:10:45:50.268   8 clean ACQ | 5 clean GUI |
 OBSID = 56984 at 2009:189:12:37:10.268   8 clean ACQ | 8 clean GUI | 
 OBSID = 10671 at 2009:189:13:27:54.231   8 clean ACQ | 5 clean GUI | 
 OBSID = 10472 at 2009:189:22:23:15.480   8 clean ACQ | 5 clean GUI | 
-OBSID = 56983 at 2009:190:00:18:22.376   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
+OBSID = 56983 at 2009:190:00:18:22.376   8 clean ACQ | 7 clean GUI | WARNINGS [ 1]
 OBSID = 56982 at 2009:190:00:28:28.810   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
 OBSID = 56981 at 2009:190:00:44:47.674   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
 OBSID = 56980 at 2009:190:01:08:41.674   0 clean ACQ | 0 clean GUI | 
@@ -120,7 +122,7 @@ OBSID = 10729 at 2009:191:12:05:42.410   8 clean ACQ | 5 clean GUI |
 OBSID = 10544 at 2009:191:15:25:22.672   8 clean ACQ | 5 clean GUI | 
          ------  2009:192:10:05:00.000   OBC Load Segment Begins     CL192:1002 
 OBSID = 10568 at 2009:192:12:56:14.672   4 clean ACQ | 4 clean GUI | WARNINGS [ 3] WARNINGS [ 4]
-OBSID = 56966 at 2009:192:14:46:30.985   4 clean ACQ | 4 clean GUI | WARNINGS [ 5] WARNINGS [ 3]
+OBSID = 56966 at 2009:192:14:46:30.985   4 clean ACQ | 4 clean GUI | WARNINGS [ 4] WARNINGS [ 3]
 OBSID = 56965 at 2009:192:14:56:37.419   8 clean ACQ | 7 clean GUI | WARNINGS [ 1]
 OBSID = 56964 at 2009:192:18:04:34.334   7 clean ACQ | 7 clean GUI | WARNINGS [ 3]
 OBSID = 56963 at 2009:193:02:59:55.361   7 clean ACQ | 7 clean GUI | WARNINGS [ 2] WARNINGS [ 1]
@@ -240,8 +242,8 @@ MP_STARCAT at 2009:187:07:42:58.619 (VCDU count = 9904464)
 [ 9]  6  1101269976   ACQ  8x8   0.985   8.130   9.641  -1557    -37  20   1  120          
 [10]  7  1101406992   ACQ  8x8   0.982   9.674  11.172    469    422  20   1  120    a2    
 
->> WARNING: 1 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Special Case ER
+>> INFO   : Only 1 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.535	-6.548	-4.774	
 Acquisition Stars Expected  : 7.80
@@ -693,9 +695,9 @@ MP_STARCAT at 2009:190:00:18:22.376 (VCDU count = 10811874)
 [ 8]  7   503054544   GUI  8x8     ---  10.333  11.844  -2072   2166   1   1   25    g4    
 [ 9]  7   503056176   ACQ  8x8   0.925  10.287  11.797    298   2240  20   1  120    a3    
 
->> WARNING: 1 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 8] Magnitude.  10.333
 >> INFO   : Special Case ER
+>> INFO   : Only 1 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-7.693	-5.818	-4.169	
 Acquisition Stars Expected  : 7.71
@@ -1294,11 +1296,11 @@ MP_STARCAT at 2009:192:14:46:30.985 (VCDU count = 11689488)
 >> WARNING: [ 2] Magnitude.  10.635
 >> WARNING: [ 3] Magnitude.  10.729
 >> WARNING: [ 9] Magnitude.  10.677
->> WARNING: 0 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 4] Marginal star. B-V = 1.500, Mag_Err = 0.29, Pos_Err = 0.05
 >> WARNING: [ 8] Magnitude.  10.425
 >> WARNING: [ 9] Marginal star. B-V = 1.500, Mag_Err = 0.35, Pos_Err = 0.09
 >> INFO   : Special Case ER
+>> INFO   : Only 0 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-3.902	-2.460	-1.350	
 Acquisition Stars Expected  : 6.14

--- a/test_regress/test/2009/JUN2209/oflsb/starcheck.txt
+++ b/test_regress/test/2009/JUN2209/oflsb/starcheck.txt
@@ -40,7 +40,7 @@ OBSID = 10087 at 2009:173:13:01:05.268   7 clean ACQ | 5 clean GUI | WARNINGS [ 
 OBSID = 10088 at 2009:173:16:23:43.158   7 clean ACQ | 5 clean GUI | WARNINGS [ 2]
 OBSID =  9921 at 2009:173:19:19:07.333   8 clean ACQ | 5 clean GUI | 
          ------  2009:174:03:53:45.802   OBC Load Segment Begins     CL174:0304 
-OBSID = 57020 at 2009:174:03:56:51.802   8 clean ACQ | 6 clean GUI | WARNINGS [ 1] WARNINGS [ 2]
+OBSID = 57020 at 2009:174:03:56:51.802   8 clean ACQ | 6 clean GUI | WARNINGS [ 2]
 OBSID = 57019 at 2009:174:04:06:58.236   8 clean ACQ | 8 clean GUI | 
 OBSID = 57018 at 2009:174:08:04:13.799   8 clean ACQ | 8 clean GUI | 
 OBSID = 57017 at 2009:174:09:51:58.394   8 clean ACQ | 8 clean GUI | 
@@ -52,7 +52,7 @@ OBSID = 10804 at 2009:174:21:58:20.429   8 clean ACQ | 5 clean GUI |
 OBSID = 10542 at 2009:175:03:41:56.429   8 clean ACQ | 5 clean GUI | 
          ------  2009:176:13:26:47.152   OBC Load Segment Begins     CL176:1304 
 OBSID = 10471 at 2009:176:13:29:53.152   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
-OBSID = 57014 at 2009:176:19:24:41.746   7 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 2]
+OBSID = 57014 at 2009:176:19:24:41.746   7 clean ACQ | 7 clean GUI | WARNINGS [ 2]
 OBSID = 57013 at 2009:176:19:35:07.579   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 57012 at 2009:176:20:32:15.081   8 clean ACQ | 8 clean GUI | 
          ------  2009:176:23:37:27.328   OBC Load Segment Begins     CL176:2304 
@@ -312,10 +312,10 @@ MP_STARCAT at 2009:174:03:56:51.802 (VCDU count = 5468301)
 [ 9]  6  1029052608   ACQ  8x8   0.985   9.336  10.844    -13   -576  20   1  120          
 [10]  7  1029048304   ACQ  8x8   0.832   9.926  11.438   -883  -1303  20   1  120    a2    
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 7] Magnitude.  10.380
 >> WARNING: [ 8] Magnitude.  10.318
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.543	-6.499	-4.673	
 Acquisition Stars Expected  : 7.72
@@ -635,10 +635,10 @@ MP_STARCAT at 2009:176:19:24:41.746 (VCDU count = 6359891)
 [10]  6   573181552   ACQ  8x8   0.937  10.220  11.719   1365  -1538  20   1  120    a2    
 [11]  7   573180520   ACQ  8x8   0.758  10.085  11.594   1255  -1100  20   1  120    a3   C
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 7] Magnitude.  10.316
 >> WARNING: [11] Marginal star. B-V = 1.500, Mag_Err = 0.35, Pos_Err = 0.05
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-7.195	-5.330	-3.707	
 Acquisition Stars Expected  : 7.53

--- a/test_regress/test/2009/OCT0509/oflsa/starcheck.txt
+++ b/test_regress/test/2009/OCT0509/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: OCT0509A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2009/OCT0509/oflsa/CR277_0801.tlr 
 Using DOT file /data/mpcrit1/mplogs/2009/OCT0509/oflsa//mps/md277_0811.dot 
@@ -86,7 +88,7 @@ OBSID = 10461 at 2009:277:20:52:19.178   8 clean ACQ | 5 clean GUI |
          ------  2009:278:20:30:00.000   OBC Load Segment Begins     CL278:2001 
 OBSID = 10728 at 2009:279:01:27:45.178   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
 OBSID = 11977 at 2009:279:06:46:22.237   8 clean ACQ | 5 clean GUI | 
-OBSID = 56782 at 2009:279:21:18:56.268   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
+OBSID = 56782 at 2009:279:21:18:56.268   8 clean ACQ | 7 clean GUI | WARNINGS [ 1]
 OBSID = 56781 at 2009:279:21:29:02.702   8 clean ACQ | 8 clean GUI | 
 OBSID = 56780 at 2009:279:22:00:29.126   8 clean ACQ | 8 clean GUI | 
 OBSID = 56779 at 2009:279:22:35:11.949   8 clean ACQ | 8 clean GUI | 
@@ -111,7 +113,7 @@ OBSID = 11748 at 2009:280:22:55:48.702   8 clean ACQ | 5 clean GUI |
 OBSID = 10880 at 2009:281:06:43:16.594   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
          ------  2009:281:19:25:00.000   OBC Load Segment Begins     CL281:1901 
 OBSID = 12003 at 2009:281:23:51:52.605   8 clean ACQ | 5 clean GUI | 
-OBSID = 56763 at 2009:282:12:45:19.295   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
+OBSID = 56763 at 2009:282:12:45:19.295   8 clean ACQ | 8 clean GUI | 
 OBSID = 56762 at 2009:282:12:55:25.729   6 clean ACQ | 8 clean GUI | WARNINGS [ 1] WARNINGS [ 3]
 OBSID = 56761 at 2009:282:17:37:12.165   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 56760 at 2009:282:23:22:49.708   7 clean ACQ | 8 clean GUI | WARNINGS [ 1]
@@ -392,9 +394,9 @@ MP_STARCAT at 2009:279:21:18:56.268 (VCDU count = 7560792)
 [ 8]  7     7865408   GUI  8x8     ---  10.324  11.828   1878    939   1   1   25    g3    
 [ 9]  7     7865232   ACQ  8x8   0.970   9.902  11.406    262   1761  20   1  120    a2    
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 8] Magnitude.  10.324
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.914	-6.881	-5.057	
 Acquisition Stars Expected  : 7.84
@@ -949,8 +951,8 @@ MP_STARCAT at 2009:282:12:45:19.295 (VCDU count = 8452043)
 [ 7]  6   335157088   BOT  8x8   0.985   9.041  10.547    424  -1920  16   1  100          
 [ 8]  7   335158416   BOT  8x8   0.970   9.937  11.438    926   1878  20   1  120  a2g3    
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.756	-6.737	-4.930	
 Acquisition Stars Expected  : 7.82

--- a/test_regress/test/2010/APR1110/oflsb/starcheck.txt
+++ b/test_regress/test/2010/APR1110/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: APR1110B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2010/APR1110/oflsb/CR101_2018.tlr 
 Using DOT file /data/mpcrit1/mplogs/2010/APR1110/oflsb//mps/md101_2002.dot 
@@ -81,7 +83,7 @@ OBSID = 56339 at 2010:101:23:03:45.255   6 clean ACQ | 7 clean GUI | WARNINGS [ 
 OBSID = 11978 at 2010:101:23:53:44.239   6 clean ACQ | 4 clean GUI | WARNINGS [ 2]
 OBSID = 11955 at 2010:102:09:18:20.627   7 clean ACQ | 4 clean GUI | WARNINGS [ 1]
 OBSID = 12047 at 2010:102:12:56:40.492   5 clean ACQ | 5 clean GUI | WARNINGS [ 3]
-OBSID = 56338 at 2010:102:16:37:11.937   6 clean ACQ | 6 clean GUI | WARNINGS [ 1] WARNINGS [ 2]
+OBSID = 56338 at 2010:102:16:37:11.937   6 clean ACQ | 6 clean GUI | WARNINGS [ 2]
 OBSID = 56337 at 2010:102:16:47:42.147   8 clean ACQ | 8 clean GUI | 
 OBSID = 56336 at 2010:102:18:32:01.206   8 clean ACQ | 8 clean GUI | 
 OBSID = 56335 at 2010:103:01:51:29.475   5 clean ACQ | 6 clean GUI | WARNINGS [ 1] WARNINGS [ 4]
@@ -317,10 +319,10 @@ MP_STARCAT at 2010:102:16:37:11.937 (VCDU count = 3774054)
 [ 7]  6   845815128   BOT  8x8   0.880  10.412  11.922    -61   1672  20   1  120  a3g3    
 [ 8]  7   845816344   BOT  8x8   0.985   9.226  10.734   2231   2293  20   1  120          
 
->> WARNING: 1 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 6] Magnitude.  10.417
 >> WARNING: [ 7] Magnitude.  10.412
 >> INFO   : Special Case ER
+>> INFO   : Only 1 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-6.758	-4.963	-3.432	
 Acquisition Stars Expected  : 7.53

--- a/test_regress/test/2010/APR1210/oflsa/starcheck.txt
+++ b/test_regress/test/2010/APR1210/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: APR1210A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2010/APR1210/oflsa/CR102_0601.tlr 
 Using DOT file /data/mpcrit1/mplogs/2010/APR1210/oflsa//mps/md102_0614.dot 
@@ -79,7 +81,7 @@ Transponder B	before 2010:108:00:50:31.485
 OBSID = 11345 at 2010:102:06:13:56.851   8 clean ACQ | 5 clean GUI | 
 OBSID = 11955 at 2010:102:07:36:47.851   6 clean ACQ | 3 clean GUI | WARNINGS [ 2]
 OBSID = 12047 at 2010:102:11:15:00.885   5 clean ACQ | 5 clean GUI | WARNINGS [ 3]
-OBSID = 56339 at 2010:102:16:37:11.937   6 clean ACQ | 6 clean GUI | WARNINGS [ 1] WARNINGS [ 2]
+OBSID = 56339 at 2010:102:16:37:11.937   6 clean ACQ | 6 clean GUI | WARNINGS [ 2]
 OBSID = 56338 at 2010:102:16:47:42.147   7 clean ACQ | 8 clean GUI | WARNINGS [ 1]
 OBSID = 56337 at 2010:102:18:29:02.971   8 clean ACQ | 8 clean GUI | 
 OBSID = 56336 at 2010:103:01:51:29.475   5 clean ACQ | 6 clean GUI | WARNINGS [ 1] WARNINGS [ 4]
@@ -109,7 +111,7 @@ OBSID = 12137 at 2010:106:14:31:02.191   7 clean ACQ | 5 clean GUI | WARNINGS [ 
 OBSID = 11582 at 2010:107:19:58:34.643   8 clean ACQ | 5 clean GUI | 
 OBSID = 11292 at 2010:107:21:48:50.643   5 clean ACQ | 5 clean GUI | WARNINGS [ 2] WARNINGS [ 1]
          ------  2010:107:23:27:41.046   OBC Load Segment Begins     CL107:2301 
-OBSID = 56331 at 2010:107:23:30:47.046   5 clean ACQ | 5 clean GUI | WARNINGS [ 3] WARNINGS [ 1]
+OBSID = 56331 at 2010:107:23:30:47.046   5 clean ACQ | 5 clean GUI | WARNINGS [ 2] WARNINGS [ 1]
 OBSID = 56330 at 2010:107:23:40:53.480   6 clean ACQ | 6 clean GUI | WARNINGS [ 1] WARNINGS [ 4]
 OBSID = 56329 at 2010:108:00:20:21.178   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 56328 at 2010:108:00:44:31.485   0 clean ACQ | 0 clean GUI | 
@@ -246,10 +248,10 @@ MP_STARCAT at 2010:102:16:37:11.937 (VCDU count = 3774054)
 [ 7]  6   845815128   BOT  8x8   0.880  10.412  11.922    -61   1672  20   1  120  a3g3    
 [ 8]  7   845816344   BOT  8x8   0.985   9.226  10.734   2231   2293  20   1  120          
 
->> WARNING: 1 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 6] Magnitude.  10.417
 >> WARNING: [ 7] Magnitude.  10.412
 >> INFO   : Special Case ER
+>> INFO   : Only 1 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-6.758	-4.963	-3.432	
 Acquisition Stars Expected  : 7.53
@@ -1063,9 +1065,9 @@ MP_STARCAT at 2010:107:23:30:47.046 (VCDU count = 5556747)
 
 >> WARNING: [ 2] Magnitude.  10.685
 >> WARNING: [ 3] Magnitude.  10.726
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 5] Magnitude.  10.503
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-5.893	-4.155	-2.709	
 Acquisition Stars Expected  : 7.21

--- a/test_regress/test/2010/JAN1110/oflsa/starcheck.txt
+++ b/test_regress/test/2010/JAN1110/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JAN1110A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2010/JAN1110/oflsa/CR011_0303.tlr 
 Using DOT file /data/mpcrit1/mplogs/2010/JAN1110/oflsa//mps/md011_0305.dot 
@@ -101,7 +103,7 @@ OBSID = 11450 at 2010:014:01:26:55.008   7 clean ACQ | 5 clean GUI | WARNINGS [ 
 OBSID = 11044 at 2010:014:02:32:52.798   8 clean ACQ | 5 clean GUI | 
 OBSID = 11058 at 2010:014:11:28:07.695   8 clean ACQ | 4 clean GUI | 
          ------  2010:015:10:08:27.483   OBC Load Segment Begins     CL015:1003 
-OBSID = 56524 at 2010:015:10:11:33.483   8 clean ACQ | 7 clean GUI | WARNINGS [ 2] 
+OBSID = 56524 at 2010:015:10:11:33.483   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] 
 OBSID = 56523 at 2010:015:10:21:36.558   8 clean ACQ | 8 clean GUI | 
 OBSID = 56522 at 2010:015:12:16:30.250   8 clean ACQ | 8 clean GUI | 
 OBSID = 56521 at 2010:015:15:36:55.697   8 clean ACQ | 8 clean GUI | 
@@ -822,9 +824,9 @@ MP_STARCAT at 2010:015:10:11:33.483 (VCDU count = 7904337)
 [10]  7  1186202864   ACQ  8x8   0.933   9.538  11.047    -89  -2173  20   1  120    a2    
 
 >> WARNING: [ 8] Monitor Commanding. DTS should be set to self
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Obsid contains flickering pixel MON
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.944	-6.882	-5.032	
 Acquisition Stars Expected  : 7.82

--- a/test_regress/test/2010/JUL0510/oflsb/starcheck.txt
+++ b/test_regress/test/2010/JUL0510/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JUL0510B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2010/JUL0510/oflsb/CR185_2300.tlr 
 Using DOT file /data/mpcrit1/mplogs/2010/JUL0510/oflsb//mps/md185_2300.dot 
@@ -93,7 +95,7 @@ OBSID = 11073 at 2010:187:22:56:33.819   8 clean ACQ | 5 clean GUI |
 OBSID = 11504 at 2010:189:02:55:03.756   8 clean ACQ | 5 clean GUI | 
 OBSID = 10136 at 2010:189:09:00:30.036   7 clean ACQ | 5 clean GUI | WARNINGS [ 2]
 OBSID = 11582 at 2010:189:20:38:24.284   8 clean ACQ | 5 clean GUI | 
-OBSID = 56144 at 2010:189:22:29:43.279   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
+OBSID = 56144 at 2010:189:22:29:43.279   8 clean ACQ | 8 clean GUI | 
 OBSID = 56143 at 2010:189:22:41:16.573   8 clean ACQ | 8 clean GUI | 
 OBSID = 56142 at 2010:189:23:13:04.429   7 clean ACQ | 8 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
 OBSID = 56141 at 2010:189:23:27:48.433   7 clean ACQ | 8 clean GUI | WARNINGS [ 2] WARNINGS [ 1]
@@ -118,7 +120,7 @@ OBSID = 11974 at 2010:191:12:39:36.925   8 clean ACQ | 5 clean GUI |
 OBSID = 12122 at 2010:191:18:33:29.925   8 clean ACQ | 5 clean GUI | 
 OBSID = 11851 at 2010:192:01:41:43.219   8 clean ACQ | 5 clean GUI | 
 OBSID = 12230 at 2010:192:03:26:33.148   6 clean ACQ | 5 clean GUI | WARNINGS [ 2]
-OBSID = 56128 at 2010:192:13:49:01.354   7 clean ACQ | 7 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
+OBSID = 56128 at 2010:192:13:49:01.354   7 clean ACQ | 7 clean GUI | WARNINGS [ 1]
 OBSID = 56127 at 2010:192:14:00:57.064   8 clean ACQ | 8 clean GUI |
 ==================================================================================== 
 OBSID: 11551  HE0435-1223            ACIS-S SIM Z offset:0     (0.00mm) Grating: NONE 
@@ -613,8 +615,8 @@ MP_STARCAT at 2010:189:22:29:43.279 (VCDU count = 16413232)
 [ 7]  6   992092280   BOT  8x8   0.970   9.853  11.359   -972  -1378  20   1  120  a2g3    
 [ 8]  7   992093896   BOT  8x8   0.932  10.177  11.688  -1407   -762  20   1  120  a2g3    
 
->> WARNING: 0 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Special Case ER
+>> INFO   : Only 0 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-7.042	-5.293	-3.771	
 Acquisition Stars Expected  : 7.65
@@ -1220,9 +1222,9 @@ MP_STARCAT at 2010:192:13:49:01.354 (VCDU count = 525608)
 [ 8]  7   845813656   GUI  8x8     ---  10.286  11.797  -2275  -1397   1   1   25    g3    
 [ 9]  7   845808520   ACQ  8x8   0.920  10.238  11.750   -567  -1303  20   1  120    a3    
 
->> WARNING: 1 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 7] Magnitude.  10.412
 >> INFO   : Special Case ER
+>> INFO   : Only 1 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-7.043	-5.223	-3.653	
 Acquisition Stars Expected  : 7.59

--- a/test_regress/test/2010/OCT1110/oflsb/starcheck.txt
+++ b/test_regress/test/2010/OCT1110/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: OCT1110B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2010/OCT1110/oflsb/CR284_0204.tlr 
 Using DOT file /data/mpcrit1/mplogs/2010/OCT1110/oflsb//mps/md284_0210.dot 
@@ -112,7 +114,7 @@ OBSID = 12329 at 2010:288:12:34:32.086   8 clean ACQ | 5 clean GUI |
          ------  2010:289:18:55:00.000   OBC Load Segment Begins     CL289:1804 
 OBSID = 12997 at 2010:290:06:13:30.297   2 clean ACQ | 2 clean GUI | WARNINGS [ 2] WARNINGS [ 9]
 OBSID = 12998 at 2010:290:08:12:35.610   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
-OBSID = 55959 at 2010:290:10:14:40.345   7 clean ACQ | 8 clean GUI | WARNINGS [ 1] WARNINGS [ 1]
+OBSID = 55959 at 2010:290:10:14:40.345   7 clean ACQ | 8 clean GUI | WARNINGS [ 1]
 OBSID = 55958 at 2010:290:10:26:13.639   6 clean ACQ | 6 clean GUI | WARNINGS [ 2] WARNINGS [ 2]
 ==================================================================================== 
 OBSID: 12470  4U 1608-522            ACIS-S SIM Z offset:0     (0.00mm) Grating: NONE 
@@ -1060,9 +1062,9 @@ MP_STARCAT at 2010:290:10:14:40.345 (VCDU count = 16740933)
 [ 8]  7    75505664   GUI  8x8     ---   9.931  11.438    157  -2433   1   1   25    g3    
 [ 9]  7    75503592   ACQ  8x8   0.847  10.415  11.922    350    391  20   1  120    a3    
 
->> WARNING: 1 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 9] Magnitude.  10.415
 >> INFO   : Special Case ER
+>> INFO   : Only 1 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-6.495	-4.808	-3.358	
 Acquisition Stars Expected  : 7.53

--- a/test_regress/test/2010/OCT2510/oflsb/starcheck.txt
+++ b/test_regress/test/2010/OCT2510/oflsb/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: OCT2510B
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2010/OCT2510/oflsb/CR297_2207.tlr 
 Using DOT file /data/mpcrit1/mplogs/2010/OCT2510/oflsb//mps/md297_2206.dot 

--- a/test_regress/test/2011/APR0411/oflsa/starcheck.txt
+++ b/test_regress/test/2011/APR0411/oflsa/starcheck.txt
@@ -51,7 +51,7 @@ OBSID = 12813 at 2011:096:21:08:11.877   5 clean ACQ | 5 clean GUI | WARNINGS [ 
          ------  2011:096:19:45:00.000   OBC Load Segment Begins     CL096:1900 
 OBSID = 12980 at 2011:096:22:59:31.877   8 clean ACQ | 5 clean GUI | 
 OBSID = 12267 at 2011:097:02:14:24.018   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
-OBSID = 55537 at 2011:097:08:43:09.572   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
+OBSID = 55537 at 2011:097:08:43:09.572   8 clean ACQ | 8 clean GUI | 
 OBSID = 55536 at 2011:097:08:55:01.015   5 clean ACQ | 6 clean GUI | WARNINGS [ 2] WARNINGS [ 4]
 OBSID = 55535 at 2011:097:10:37:09.928   7 clean ACQ | 7 clean GUI | WARNINGS [ 2] 
 OBSID = 55534 at 2011:097:15:19:00.051   8 clean ACQ | 8 clean GUI | 
@@ -612,8 +612,8 @@ MP_STARCAT at 2011:097:08:43:09.572 (VCDU count = 7604005)
 [ 9]  6  1063259504   ACQ  8x8   0.985   8.808  10.312  -1588    -18  20   1  120          
 [10]  7  1063271536   ACQ  8x8   0.946   9.953  11.453   2265   -896  20   1  120    a2    
 
->> WARNING: 0 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Special Case ER
+>> INFO   : Only 0 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-7.608	-5.778	-4.167	
 Acquisition Stars Expected  : 7.73

--- a/test_regress/test/2011/DEC1211/oflsa/starcheck.txt
+++ b/test_regress/test/2011/DEC1211/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: DEC1211A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2011/DEC1211/oflsa/CR346_0007.tlr 
 Using DOT file /data/mpcrit1/mplogs/2011/DEC1211/oflsa//mps/md346_0006.dot 

--- a/test_regress/test/2011/DEC1211/oflsa/v_starcheck.txt
+++ b/test_regress/test/2011/DEC1211/oflsa/v_starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: DEC1211A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2011/DEC1211/oflsa/CR346_0007.tlr 
 Using DOT file /data/mpcrit1/mplogs/2011/DEC1211/oflsa//mps/md346_0006.dot 

--- a/test_regress/test/2011/JAN1711/oflsa/starcheck.txt
+++ b/test_regress/test/2011/JAN1711/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JAN1711A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2011/JAN1711/oflsa/CR017_1002.tlr 
 Using DOT file /data/mpcrit1/mplogs/2011/JAN1711/oflsa//mps/md017_1042.dot 
@@ -80,7 +82,7 @@ OBSID = 12872 at 2011:017:10:23:21.565   6 clean ACQ | 4 clean GUI | WARNINGS [ 
 OBSID = 12280 at 2011:017:12:48:36.214   8 clean ACQ | 5 clean GUI | 
 OBSID = 12746 at 2011:017:16:02:12.214   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
 OBSID = 13013 at 2011:017:18:40:29.214   8 clean ACQ | 5 clean GUI | 
-OBSID = 55730 at 2011:018:00:39:35.018   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
+OBSID = 55730 at 2011:018:00:39:35.018   8 clean ACQ | 8 clean GUI | 
 OBSID = 55729 at 2011:018:00:51:08.312   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 55728 at 2011:018:01:12:49.409   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
 OBSID = 55727 at 2011:018:01:36:43.409   0 clean ACQ | 0 clean GUI | 
@@ -107,7 +109,7 @@ OBSID = 13132 at 2011:019:12:08:24.273   7 clean ACQ | 5 clean GUI | WARNINGS [ 
 OBSID = 12837 at 2011:019:20:24:35.273   8 clean ACQ | 5 clean GUI | 
 OBSID = 12393 at 2011:019:22:14:39.133   5 clean ACQ | 4 clean GUI | WARNINGS [ 3] 
          ------  2011:020:12:55:00.000   OBC Load Segment Begins     CL020:1202 
-OBSID = 55711 at 2011:020:16:16:53.865   5 clean ACQ | 5 clean GUI | WARNINGS [ 4] WARNINGS [ 1]
+OBSID = 55711 at 2011:020:16:16:53.865   5 clean ACQ | 5 clean GUI | WARNINGS [ 3] WARNINGS [ 1]
 OBSID = 55710 at 2011:020:16:28:27.159   8 clean ACQ | 8 clean GUI | 
 OBSID = 55709 at 2011:020:17:57:11.748   8 clean ACQ | 8 clean GUI | 
 OBSID = 55708 at 2011:020:19:47:01.526   8 clean ACQ | 8 clean GUI | 
@@ -285,8 +287,8 @@ MP_STARCAT at 2011:018:00:39:35.018 (VCDU count = 14408723)
 [ 9]  6   151914712   ACQ  8x8   0.909  10.179  11.688    456    745  19   1  115    a2    
 [10]  7   151917032   ACQ  8x8   0.985   8.061   9.562    797   2209  20   1  120    a3    
 
->> WARNING: 1 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Special Case ER
+>> INFO   : Only 1 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-7.305	-5.464	-3.865	
 Acquisition Stars Expected  : 7.65
@@ -964,9 +966,9 @@ MP_STARCAT at 2011:020:16:16:53.865 (VCDU count = 15302533)
 >> WARNING: [ 6] Nearby ACA bad pixel. Y,Z,Radial seps:  13,   8,  15
 >> WARNING: [ 8] Magnitude.  10.666
 >> WARNING: [ 9] Magnitude.  10.633
->> WARNING: 0 star(s) brighter than 9 mag. Perigee requires at least 3
 >> WARNING: [ 2] Magnitude.  10.370
 >> INFO   : Special Case ER
+>> INFO   : Only 0 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-6.880	-5.056	-3.474	
 Acquisition Stars Expected  : 7.46

--- a/test_regress/test/2011/MAR1411/oflsa/starcheck.txt
+++ b/test_regress/test/2011/MAR1411/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: MAR1411A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2011/MAR1411/oflsa/CR073_1505.tlr 
 Using DOT file /data/mpcrit1/mplogs/2011/MAR1411/oflsa//mps/md073_1506.dot 

--- a/test_regress/test/2012/JAN3012/oflsa/starcheck.txt
+++ b/test_regress/test/2012/JAN3012/oflsa/starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JAN3012A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2012/JAN3012/oflsa/CR030_0605.tlr 
 Using DOT file /data/mpcrit1/mplogs/2012/JAN3012/oflsa//mps/md030_0630.dot 

--- a/test_regress/test/2012/JAN3012/oflsa/v_starcheck.txt
+++ b/test_regress/test/2012/JAN3012/oflsa/v_starcheck.txt
@@ -28,6 +28,8 @@ Using ACABadPixel file from 2015014 Dark Cal
 
 ------------  DARK CURRENT CALIBRATION CHECKS  -----------------
 
+Comm Summary: JAN3012A
+
 VERBOSE SUPERVERBOSE
 Using tlr file /data/mpcrit1/mplogs/2012/JAN3012/oflsa/CR030_0605.tlr 
 Using DOT file /data/mpcrit1/mplogs/2012/JAN3012/oflsa//mps/md030_0630.dot 

--- a/test_regress/test/2013/JUL2913/oflsa/starcheck.txt
+++ b/test_regress/test/2013/JUL2913/oflsa/starcheck.txt
@@ -44,7 +44,7 @@ OBSID = 15303 at 2013:211:10:27:25.630   7 clean ACQ | 5 clean GUI | WARNINGS [ 
          ------  2013:211:12:35:01.285   OBC Load Segment Begins     CL211:1217 
 OBSID = 14654 at 2013:211:16:36:14.651   8 clean ACQ | 5 clean GUI | 
 OBSID = 14597 at 2013:212:06:17:20.845   8 clean ACQ | 5 clean GUI | 
-OBSID = 53516 at 2013:212:15:17:55.267   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
+OBSID = 53516 at 2013:212:15:17:55.267   8 clean ACQ | 8 clean GUI | 
 OBSID = 53515 at 2013:212:15:29:28.561   8 clean ACQ | 8 clean GUI | 
 OBSID = 53514 at 2013:212:16:00:55.713   8 clean ACQ | 8 clean GUI | 
 OBSID = 53513 at 2013:212:17:13:38.549   8 clean ACQ | 7 clean GUI | WARNINGS [ 1] 
@@ -55,7 +55,7 @@ OBSID = 53510 at 2013:212:23:20:14.029   6 clean ACQ | 6 clean GUI | WARNINGS [ 
 OBSID = 14663 at 2013:213:01:19:25.355   7 clean ACQ | 4 clean GUI | WARNINGS [ 1]
 OBSID = 15180 at 2013:213:14:15:50.255   7 clean ACQ | 5 clean GUI | WARNINGS [ 1]
          ------  2013:214:12:20:00.000   OBC Load Segment Begins     CL214:1217 
-OBSID = 53509 at 2013:215:05:56:21.844   8 clean ACQ | 8 clean GUI | WARNINGS [ 1] 
+OBSID = 53509 at 2013:215:05:56:21.844   8 clean ACQ | 8 clean GUI | 
 OBSID = 53508 at 2013:215:06:08:14.272   8 clean ACQ | 8 clean GUI | 
 OBSID = 53507 at 2013:215:07:30:26.958   8 clean ACQ | 8 clean GUI | 
 OBSID = 53506 at 2013:215:08:34:22.768   7 clean ACQ | 8 clean GUI | WARNINGS [ 1]
@@ -419,8 +419,8 @@ MP_STARCAT at 2013:212:15:17:55.267 (VCDU count = 9820823)
 [10]  6  1132338408   ACQ  8x8   0.976   9.493  11.000   1364  -1034  20   1  120    a2    
 [11]  7  1132340392   ACQ  8x8   0.971   9.566  11.078    315   1353  20   1  120    a2    
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-8.777	-6.770	-4.971	
 Acquisition Stars Expected  : 7.83
@@ -686,8 +686,8 @@ MP_STARCAT at 2013:215:05:56:21.844 (VCDU count = 10700848)
 [ 9]  6   115349744   ACQ  8x8   0.840  10.190  11.688    437  -2296  20   1  120    a2    
 [10]  7   115347520   ACQ  8x8   0.850  10.164  11.672   -267   -154  20   1  120    a2    
 
->> WARNING: 2 star(s) brighter than 9 mag. Perigee requires at least 3
 >> INFO   : Special Case ER
+>> INFO   : Only 2 star(s) brighter than 9 mag. Acceptable for Special Case ER
 
 Probability of acquiring 2,3, and 4 or fewer stars (10^x):	-6.328	-4.541	-3.019	
 Acquisition Stars Expected  : 7.30


### PR DESCRIPTION
Obs 17383 in FEB2315A has a non-standard dither with a 64 arcsec amplitude in Z.

From Eric:

In order to have these dither parameters, dither commanding must be similar to that for observations with monitor windows.
 
Dither (using standard parameters) must be disabled 1 min prior to the end of the maneuver to the observation that will use the large dither parameters.  5 min after the end of the maneuver (when all stars should have been acquired and are being tracked), dither (using the large parameters) can be re-enabled.  Finally, 5 min prior to the end of the observation, dither must be commanded back to standard parameters.
 