### PR TITLE
Check catalogs using only dither from backstop or history

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -21,6 +21,7 @@ package Ska::Starcheck::Obsid;
 use strict;
 use warnings;
 
+use List::Util qw( max );
 use Quat;
 use Ska::ACACoordConvert;
 use File::Basename;
@@ -1077,8 +1078,7 @@ sub check_star_catalog {
 
     my $dither;			# Global dither for observation
     if (defined $self->{cmd_dither_y_amp} and defined $self->{cmd_dither_z_amp}) {
-	$dither = ($self->{cmd_dither_y_amy} > $self->{cmd_dither_z_amp} ?
-		   $self->{cmd_dither_y_amp} : $self->{cmd_dither_z_amp});
+	$dither = max($self->{cmd_dither_y_amy}, $self->{cmd_dither_z_amp});
     } else {
 	$dither = 20.0;
     }

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -1080,7 +1080,6 @@ sub check_star_catalog {
 	$dither = ($self->{cmd_dither_y_amy} > $self->{cmd_dither_z_amp} ?
 		   $self->{cmd_dither_y_amp} : $self->{cmd_dither_z_amp});
     } else {
-        $self->{used_default_dither} = 1;
 	$dither = 20.0;
     }
 

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -686,8 +686,6 @@ sub check_dither {
     if (($bs_val eq 'ENAB') and (defined $dither->{ampl_y} and defined $dither->{ampl_p})){
         $self->{cmd_dither_y_amp} = $dither->{ampl_y};
         $self->{cmd_dither_z_amp} = $dither->{ampl_p};
-        $self->{cmd_dither_y_period} = $dither->{period_y};
-        $self->{cmd_dither_z_period} = $dither->{period_z};
         if (not standard_dither($dither)){
             push @{$self->{yellow_warn}}, "$alarm Non-standard dither\n";
             if ($dither->{ampl_y} > $large_dith_thresh or $dither->{ampl_p} > $large_dith_thresh){

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -681,10 +681,12 @@ sub check_dither {
             push @{$self->{warn}}, $warn;
         }
     }
-
-
     # Check for standard and large dither based solely on backstop/history values
     if (($bs_val eq 'ENAB') and (defined $dither->{ampl_y} and defined $dither->{ampl_p})){
+        $self->{cmd_dither_y_amp} = $dither->{ampl_y};
+        $self->{cmd_dither_z_amp} = $dither->{ampl_p};
+        $self->{cmd_dither_y_period} = $dither->{period_y};
+        $self->{cmd_dither_z_period} = $dither->{period_z};
         if (not standard_dither($dither)){
             push @{$self->{yellow_warn}}, "$alarm Non-standard dither\n";
             if ($dither->{ampl_y} > $large_dith_thresh or $dither->{ampl_p} > $large_dith_thresh){
@@ -1074,10 +1076,11 @@ sub check_star_catalog {
     my $min_z = $z_ang_max;
 
     my $dither;			# Global dither for observation
-    if (defined $self->{DITHER_Y_AMP} and defined $self->{DITHER_Z_AMP}) {
-	$dither = ($self->{DITHER_Y_AMP} > $self->{DITHER_Z_AMP} ?
-		   $self->{DITHER_Y_AMP} : $self->{DITHER_Z_AMP}) * 3600.0;
+    if (defined $self->{cmd_dither_y_amp} and defined $self->{cmd_dither_z_amp}) {
+	$dither = ($self->{cmd_dither_y_amy} > $self->{cmd_dither_z_amp} ?
+		   $self->{cmd_dither_y_amp} : $self->{cmd_dither_z_amp});
     } else {
+        $self->{used_default_dither} = 1;
 	$dither = 20.0;
     }
 

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -1076,7 +1076,7 @@ sub check_star_catalog {
 
     my $dither;			# Global dither for observation
     if (defined $self->{cmd_dither_y_amp} and defined $self->{cmd_dither_z_amp}) {
-	$dither = max($self->{cmd_dither_y_amy}, $self->{cmd_dither_z_amp});
+	$dither = max($self->{cmd_dither_y_amp}, $self->{cmd_dither_z_amp});
     } else {
 	$dither = 20.0;
     }

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -606,9 +606,9 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->check_monitor_commanding(\@bs, $or{$obsid});
     $obs{$obsid}->check_flick_pix_mon();
     $obs{$obsid}->set_dynamic_mag_limits();
+    $obs{$obsid}->check_dither($dither);
     $obs{$obsid}->check_star_catalog($or{$obsid}, $par{vehicle});
     $obs{$obsid}->check_sim_position(@sim_trans) unless $par{vehicle};
-    $obs{$obsid}->check_dither($dither);
 	$obs{$obsid}->check_momentum_unload(\@bs);
     $obs{$obsid}->check_for_special_case_er();
     $obs{$obsid}->check_bright_perigee($radmon);


### PR DESCRIPTION
Check catalogs using only dither from backstop or history.  

This still compares backstop dither state to OR state and compares OR vs backstop amplitudes if backstop commanding includes amplitude.  However, instead of using the OR amplitude by default in check_catalog(), the default value of 20 arcsecs will be used unless an AODITPAR has occurred to set dither parameters explicitly in backstop.