### PR TITLE
Handle warnings on magnitude a little differently from other warnings

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -1958,21 +1958,42 @@ sub print_report {
     
     $o .= "\n" if (@{$self->{warn}} || @{$self->{yellow_warn}} || @{$self->{fyi}} );
 
+    my $mag_regex = qr/^$alarm \[\s?\d+\] Magnitude. \s+\d+\.\d+\n/;
+    my @mag_red = grep {/$mag_regex/} @{$self->{warn}};
+    my @non_mag_red = grep {!/$mag_regex/} @{$self->{warn}};
+    my @mag_yellow = grep {/$mag_regex/} @{$self->{yellow_warn}};
+    my @non_mag_yellow = grep {!/$mag_regex/} @{$self->{yellow_warn}};
 
-
-    if (@{$self->{warn}}) {
+    if (@mag_red){
 	$o .= "${red_font_start}";
-	foreach (@{$self->{warn}}) {
+	foreach (@mag_red) {
 	    $o .= $_;
 	}
-	$o .= "${font_stop}";
+        $o .= "${font_stop}";
     }
-    if (@{$self->{yellow_warn}}) {
+    if (@mag_yellow){
 	$o .= "${yellow_font_start}";
-	foreach (@{$self->{yellow_warn}}) {
+	foreach (@mag_yellow) {
 	    $o .= $_;
 	}
-	$o .= "${font_stop}";
+        $o .= "${font_stop}";
+    }
+
+    $o .= "\n" if ((@mag_red) || (@mag_yellow));
+
+    if (@non_mag_red){
+	$o .= "${red_font_start}";
+	foreach (@non_mag_red) {
+	    $o .= $_;
+	}
+        $o .= "${font_stop}";
+    }
+    if (@non_mag_yellow){
+	$o .= "${yellow_font_start}";
+	foreach (@non_mag_yellow) {
+	    $o .= $_;
+	}
+        $o .= "${font_stop}";
     }
     if (@{$self->{fyi}}) {
 	$o .= "${blue_font_start}";

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -1282,7 +1282,7 @@ sub check_star_catalog {
 	# FID magnitude limits ACA-011
 	if ($type eq 'FID') {
 	    if ($mag =~ /---/ or $mag < $fid_bright or $mag > $fid_faint) {
-		push @warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i, $mag =~ /---/ ? 0 : $mag;
+		push @warn, sprintf "$alarm [%2d] Fid Magnitude.  %6.3f\n",$i, $mag =~ /---/ ? 0 : $mag;
 	    } 
 	}
 

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -796,13 +796,19 @@ for my $obs_idx (0 .. $#obsid_id) {
     }
 
 
+    my $alarm = ">> WARNING:";
+    my $mag_regex = qr/^$alarm \[\s?\d+\] Magnitude. \s+\d+\.\d+\n/;
     if (@{$obs{$obsid}->{warn}}) {
-	my $count_red_warn = $#{$obs{$obsid}->{warn}}+1;
-	$out .= sprintf("${red_font_start}WARNINGS [%2d]${font_stop} ", $count_red_warn);
+        my @non_mag_warn = grep {!/$mag_regex/} @{$obs{$obsid}->{warn}};
+        if (scalar(@non_mag_warn)){
+            $out .= sprintf("${red_font_start}WARNINGS [%2d]${font_stop} ", scalar(@non_mag_warn));
+        }
     } 
     if (@{$obs{$obsid}->{yellow_warn}}) {
-	my $count_yellow_warn = $#{$obs{$obsid}->{yellow_warn}}+1;
-	$out .= sprintf("${yellow_font_start}WARNINGS [%2d]${font_stop}", $count_yellow_warn);
+        my @non_mag_warn = grep {!/$mag_regex/} @{$obs{$obsid}->{yellow_warn}};
+        if (scalar(@non_mag_warn)){
+            $out .= sprintf("${yellow_font_start}WARNINGS [%2d]${font_stop} ", scalar(@non_mag_warn));
+        }
     }
     $out .= "\n";
 }


### PR DESCRIPTION
While magnitude warnings are likely to improve with a transition to probability models that are calibrated with the MS filter disabled, at this point we have lots of warnings related to Magnitude which pop up on the summary and are printed for each observation.  This PR removes single magnitude warnings from the summary counts but still includes them in the warning "penalties" on each star for the warning-free counts.  Additionally magnitude warnings are printed in a separate chunk for each observation.

At this point, we care more about a single red warning on the overall probability of the observation than we care about say 5 red magnitude warnings, so I think this PR improves signal to noise a bit.
