### PR TITLE
Copy starcheck python files into working directory in regression test

### DIFF
--- a/src/run_regress
+++ b/src/run_regress
@@ -34,8 +34,10 @@ RunRegression()
     cd $test
 
 
-  # Run test version.  Use the 'starcheck' launcher to activate the dev environment
+  # Run test version.  Use the 'sandbox_starcheck' launcher to activate the dev environment
   #
+    echo "Copying python files for local use"
+    cp -Ruva ${home}/starcheck .
     echo "Running: ${home}/sandbox_starcheck -vehicle -agasc $agasc -fid_char $fid_char -dir $mphome/$load"
     echo "******************** (TEST VEHICLE) $load *******************" >> $vlog
     ${home}/sandbox_starcheck -vehicle -agasc $agasc -fid_char $fid_char -dir $mphome/$load 2>&1| tee -a $vlog
@@ -71,8 +73,10 @@ RunRegression()
   echo "cd $test"
   cd $test
 
-  # Run test version.  Use the 'starcheck' launcher to activate the dev environment
+  # Run test version.  Use the 'sandbox_starcheck' launcher to activate the dev environment
   #
+  echo "Copying python files for local use"
+  cp -Ruva ${home}/starcheck .
   echo "Running: ${home}/sandbox_starcheck -agasc $agasc -fid_char $fid_char -dir $mphome/$load"
   echo "******************** (TEST) $load *******************" >> $log
   ${home}/sandbox_starcheck -agasc $agasc -fid_char $fid_char -dir $mphome/$load 2>&1| tee -a $log


### PR DESCRIPTION
Copy starcheck python files into working directory in regression test

' ' is at the beginnign of sys.path, so copying over the top level python
files into '' before running each regression starcheck run gets around the
path issue that can arise when a starcheck egg dir in the environment is
before the PYTHONPATH used in the sandbox_starcheck testing.