### PR TITLE
Increase CCD "red" limit to -12.5C

### DIFF
--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -8,7 +8,7 @@
 ##*******************************************************************************
 
 
-my $version = '11.10';
+my $version = '11.11';
 
 # Set defaults and get command line options
 

--- a/starcheck/version.py
+++ b/starcheck/version.py
@@ -14,7 +14,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '11.10'
+version = '11.11'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])

--- a/starcheck_data/characteristics.yaml
+++ b/starcheck_data/characteristics.yaml
@@ -60,8 +60,8 @@ no_starcat_oflsid:
    - RDE
    - DC_T
 
-ccd_temp_yellow_limit: -14.5
-ccd_temp_red_limit: -13.5
+ccd_temp_yellow_limit: -13.5
+ccd_temp_red_limit: -12.5
 
 n100_warm_frac_default: .15
 


### PR DESCRIPTION
Increase CCD "red" limit 1.0C to -12.5C and yellow warning limit to -13.5 C.