### PR TITLE
Implement changes for dynamical offsets

### DIFF
--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -693,13 +693,16 @@ if (@global_warn) {
 my $CHAR_REQUIRED_AFTER = '2015:315:00:00:00.000';
 if ((defined $char_file) or ($bs[0]->{time} > date2time($CHAR_REQUIRED_AFTER))){
     $out .= "------------  VERIFY ATTITUDE (SI_ALIGN CHECK)  -----------------\n\n";
-    if (not defined $char_file){
-        $out .= "Error.  Characteristics file not found. \n";
-    }
     # dynamic aimpoint files are required after 21-Aug-2016
     my $AIMPOINT_REQUIRED_AFTER = '2016:234:00:00:00.000';
     if ((not defined $aimpoint_file) and ($bs[0]->{time} > date2time($AIMPOINT_REQUIRED_AFTER))){
         $out .= "Error.  dynamic aimpoint file not found. \n";
+    }
+    # The attitude checks are not possible without the char file but are possible without the
+    # dynamic aimpoint file, so this is an if/else that controls doing the check only on the
+    # presence of the char_file.
+    if (not defined $char_file){
+        $out .= "Error.  Characteristics file not found. \n";
     }
     else{
         my $att_report = "${STARCHECK}/pcad_att_check.txt";

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -141,6 +141,7 @@ my $dither_file= get_file("$par{dir}/History/DITHER.txt*",'dither');
 my $radmon_file= get_file("$par{dir}/History/RADMON.txt*", 'radmon');
 my $simtrans_file= get_file("$par{dir}/History/SIMTRANS.txt*", 'simtrans');
 my $simfocus_file= get_file("$par{dir}/History/SIMFOCUS.txt*", 'simfocus');
+my $aimpoint_file= get_file("$par{dir}/output/*_dynamical_offsets.txt", 'aimpoint');
 
 # Check for characteristics.  Ignore the get_file required vs not API and just pre-check
 # to see if there is characteristics
@@ -695,7 +696,7 @@ if ((defined $char_file) or ($bs[0]->{time} > date2time($CHAR_REQUIRED_AFTER))){
         my $att_report = "${STARCHECK}/pcad_att_check.txt";
         my $att_ok = make_pcad_attitude_check_report(
             $backstop, $or_file, $mm_file, $simtrans_file, $simfocus_file,
-            $char_file, $att_report);
+            $char_file, $att_report, $aimpoint_file);
         if ($att_ok){
             $out .= "<A HREF=\"${att_report}\">[OK] Coordinates as expected.</A>\n";
         }

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -141,7 +141,6 @@ my $dither_file= get_file("$par{dir}/History/DITHER.txt*",'dither');
 my $radmon_file= get_file("$par{dir}/History/RADMON.txt*", 'radmon');
 my $simtrans_file= get_file("$par{dir}/History/SIMTRANS.txt*", 'simtrans');
 my $simfocus_file= get_file("$par{dir}/History/SIMFOCUS.txt*", 'simfocus');
-my $aimpoint_file= get_file("$par{dir}/output/*_dynamical_offsets.txt", 'aimpoint');
 
 # Check for characteristics.  Ignore the get_file required vs not API and just pre-check
 # to see if there is characteristics
@@ -153,7 +152,12 @@ for my $char_glob ("$par{dir}/mps/ode/characteristics/L_*_CHARACTERIS*",
         last;
     }
 }
-
+# Check for a dynamic aimpoint file.  Precheck existence of file to avoid errors about a
+# missing file on historical products that won't have this file
+my $aimpoint_file;
+if (glob("$par{dir}/output/*_dynamical_offsets.txt")){
+    $aimpoint_file = get_file("$par{dir}/output/*_dynamical_offsets.txt", 'aimpoint');
+}
 
 my $config_file = get_file("$Starcheck_Data/$par{config_file}*", 'config', 'required');
 
@@ -691,6 +695,11 @@ if ((defined $char_file) or ($bs[0]->{time} > date2time($CHAR_REQUIRED_AFTER))){
     $out .= "------------  VERIFY ATTITUDE (SI_ALIGN CHECK)  -----------------\n\n";
     if (not defined $char_file){
         $out .= "Error.  Characteristics file not found. \n";
+    }
+    # dynamic aimpoint files are required after 21-Aug-2016
+    my $AIMPOINT_REQUIRED_AFTER = '2016:234:00:00:00.000';
+    if ((not defined $aimpoint_file) and ($bs[0]->{time} > date2time($AIMPOINT_REQUIRED_AFTER))){
+        $out .= "Error.  dynamic aimpoint file not found. \n";
     }
     else{
         my $att_report = "${STARCHECK}/pcad_att_check.txt";

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -8,7 +8,7 @@
 ##*******************************************************************************
 
 
-my $version = '11.11';
+my $version = '11.12';
 
 # Set defaults and get command line options
 

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -82,11 +82,15 @@ def make_pcad_attitude_check_report(backstop_file, or_list_file=None, mm_file=No
         all_ok = False
 
     # If dynamical offsets file is available then load was planned using
-    # Matlab tools 2016:210 later, which implements the "Cycle 18 aimpoint
+    # Matlab tools 2016_210 later, which implements the "Cycle 18 aimpoint
     # transition plan".  This code injects new OR list attributes for the
     # dynamical offset.
     if dynamic_offsets_file is not None and or_list is not None:
+        # Existing OFLS characteristics file is not relevant for post 2016_210.
+        # Products are planned using the Matlab tools SI align which matches the
+        # baseline mission align matrix from pre-November 2015.
         ofls_characteristics_file = None
+
         lines.append('INFO: using dynamic offsets file {}'.format(dynamic_offsets_file))
         or_map = {or_['obsid']: or_ for or_ in or_list}
 

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -1,7 +1,8 @@
 import re
 import hopper
-from parse_cm import read_backstop, read_maneuver_summary
+from parse_cm import read_backstop, read_maneuver_summary, read_or_list
 from Chandra.Time import DateTime
+from astropy.table import Table
 
 
 def check_characteristics_date(ofls_characteristics_file, ref_date=None):
@@ -55,32 +56,61 @@ def recent_sim_history(time, file):
 def make_pcad_attitude_check_report(backstop_file, or_list_file=None, mm_file=None,
                                     simtrans_file=None, simfocus_file=None,
                                     ofls_characteristics_file=None, out=None,
+                                    dynamic_offsets_file=None,
                                     ):
     """
     Make a report for checking PCAD attitudes
 
     """
+    all_ok = True
+    lines = []  # output report lines
+
     mm = read_maneuver_summary(mm_file)
     q = [mm[0][key] for key in ['q1_0', 'q2_0', 'q3_0', 'q4_0']]
     bs = read_backstop(backstop_file)
     simfa_time, simfa = recent_sim_history(DateTime(bs[0]['date']).secs,
-                                       simfocus_file)
+                                           simfocus_file)
     simpos_time, simpos = recent_sim_history(DateTime(bs[0]['date']).secs,
-                                       simtrans_file)
+                                             simtrans_file)
     initial_state = {'q_att': q,
                      'simpos': simpos,
                      'simfa_pos': simfa}
+
+    or_list = None if or_list_file is None else read_or_list(or_list_file)
+    if or_list is None:
+        lines.append('ERROR: No OR list provided, cannot check attitudes')
+        all_ok = False
+
+    # If dynamical offsets file is available then load was planned using
+    # Matlab tools 2016:210 later, which implements the "Cycle 18 aimpoint
+    # transition plan".  This code injects new OR list attributes for the
+    # dynamical offset.
+    if dynamic_offsets_file is not None and or_list is not None:
+        ofls_characteristics_file = None
+        lines.append('INFO: using dynamic offsets file {}'.format(dynamic_offsets_file))
+        or_map = {or_['obsid']: or_ for or_ in or_list}
+
+        doffs = Table.read(dynamic_offsets_file, format='ascii.basic', guess=False)
+        for doff in doffs:
+            obsid = doff['obsid']
+            if obsid in or_map:
+                or_map[obsid]['aca_offset_y'] = doff['aca_offset_y'] / 3600.
+                or_map[obsid]['aca_offset_z'] = doff['aca_offset_z'] / 3600.
+
+        # Check that obsids in OR list match those in dynamic offsets table
+        obsid_mismatch = set(or_map) ^ set(doffs['obsid'])
+        if obsid_mismatch:
+            all_ok = False
+            lines.append('WARNING: mismatch between OR-list and dynamic offsets table {}'
+                         .format(obsid_mismatch))
 
     # Run the commands and populate attributes in `sc`, the spacecraft state.
     # In particular sc.checks is a dict of checks by obsid.
     # Any state value (e.g. obsid or q_att) has a corresponding plural that
     # gives the history of updates as a dict with a `value` and `date` key.
-    sc = hopper.run_cmds(backstop_file, or_list_file, ofls_characteristics_file,
+    sc = hopper.run_cmds(backstop_file, or_list, ofls_characteristics_file,
                          initial_state=initial_state)
-    all_ok = True
-
     # Iterate through obsids in order
-    lines = []
     obsids = [obj['value'] for obj in sc.obsids]
     for obsid in obsids:
         if obsid not in sc.checks:
@@ -99,7 +129,7 @@ def make_pcad_attitude_check_report(backstop_file, or_list_file=None, mm_file=No
                 lines.append(line)
 
     if out is not None:
-       report = open(out, 'w')
-       report.writelines("\n".join(lines))
+        with open(out, 'w') as fh:
+            fh.writelines("\n".join(lines))
 
     return all_ok

--- a/starcheck/version.py
+++ b/starcheck/version.py
@@ -14,7 +14,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '11.11'
+version = '11.12'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])


### PR DESCRIPTION
Implement changes to support checking PCAD attitudes for loads created with Matlab tools 2016_210 and later. This implements the Cycle 18 aimpoint transition plan with ACA CCD-based dynamical aimpoint offsets.

Goes along with https://github.com/sot/hopper/pull/8.