### PR TITLE
Calculate the expected aca offsets 

### DIFF
--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -571,11 +571,6 @@ eval{
                                           char_file => "$Starcheck_Data/characteristics.yaml",
                                           orlist => $or_file,
                                       });
-    open(my $JSON_OBS_TEMP, "> $STARCHECK/obsid_thermal.json")
-        or die "Couldn't open $STARCHECK/obsid_thermal.json for writing\n";
-    print $JSON_OBS_TEMP $json_obsid_temps;
-    close($JSON_OBS_TEMP);
-
     # convert back from JSON outside
     $obsid_temps = JSON::from_json($json_obsid_temps);
 };
@@ -586,6 +581,10 @@ if ($@){
 if ($obsid_temps){
     foreach my $obsid (@obsid_id) {
         $obs{$obsid}->set_ccd_temps($obsid_temps);
+        # put all the interval pieces in the main obsid structure
+        if (defined $obsid_temps->{$obs{$obsid}->{obsid}}){
+            $obs{$obsid}->{thermal} = $obsid_temps->{$obs{$obsid}->{obsid}};
+        }
     }
 }
 

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -569,6 +569,7 @@ eval{
                                           json_obsids => $json_text,
                                           model_spec => "$Starcheck_Data/aca_spec.json",
                                           char_file => "$Starcheck_Data/characteristics.yaml",
+                                          orlist => $or_file,
                                       });
     # convert back from JSON outside
     $obsid_temps = JSON::from_json($json_obsid_temps);

--- a/src/starcheck.pl
+++ b/src/starcheck.pl
@@ -571,6 +571,11 @@ eval{
                                           char_file => "$Starcheck_Data/characteristics.yaml",
                                           orlist => $or_file,
                                       });
+    open(my $JSON_OBS_TEMP, "> $STARCHECK/obsid_thermal.json")
+        or die "Couldn't open $STARCHECK/obsid_thermal.json for writing\n";
+    print $JSON_OBS_TEMP $json_obsid_temps;
+    close($JSON_OBS_TEMP);
+
     # convert back from JSON outside
     $obsid_temps = JSON::from_json($json_obsid_temps);
 };

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -201,7 +201,7 @@ def get_interval_data(intervals, times, ccd_temp, obsreqs=None):
         stop_idx = 1 + np.searchsorted(times, interval['tstop'])
         start_idx = -1 + np.searchsorted(times, interval['tstart'])
         ok_temps = ccd_temp[start_idx:stop_idx]
-        itimes = times[start_idx:stop_idx]
+        ok_times = times[start_idx:stop_idx]
         if len(ok_temps) > 0:
             obs['ccd_temp'] = np.max(ok_temps)
             obs['n100_warm_frac'] = dark_model.get_warm_fracs(
@@ -215,7 +215,7 @@ def get_interval_data(intervals, times, ccd_temp, obsreqs=None):
                                            obsreq['chip_id'],
                                            obsreq['chipx'],
                                            obsreq['chipy'],
-                                           time=itimes,
+                                           time=ok_times,
                                            t_ccd=ok_temps)
                 obs['aca_offset_y'] = np.mean(ddy)
                 obs['aca_offset_z'] = np.mean(ddz)

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -186,9 +186,13 @@ def get_interval_data(intervals, times, ccd_temp, obsreqs=None):
     """
     Determine the max temperature and mean offsets over each interval.
 
+    If the OR list is supplied (in the obsreqs dictionary) the ACA offsets will
+    also be calculated for each interval and included in the returned data.
+
     :param intervals: list of dictionaries describing obsid/catalog intervals
     :param times: times of the temperature samples
     :param ccd_temp: ccd temperature values
+    :param obsreqs: optional dictionary of OR list from parse_cm.or_list
 
     :returns: dictionary (keyed by obsid) of intervals with max ccd_temps
     """

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -206,6 +206,8 @@ def get_interval_data(intervals, times, ccd_temp, obsreqs=None):
             obs['ccd_temp'] = np.max(ok_temps)
             obs['n100_warm_frac'] = dark_model.get_warm_fracs(
                 100, interval['tstart'], np.max(ok_temps))
+        if obsreqs is None:
+            obsreqs = {}
         if interval['obsid'] in obsreqs and len(ok_temps) > 0:
             obsreq = obsreqs[interval['obsid']]
             if 'chip_id' in obsreq:

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -174,9 +174,7 @@ def get_ccd_temps(oflsdir, outdir='out',
     make_check_plots(outdir, states, times,
                      ccd_temp, tstart, tstop, char=char)
     intervals = get_obs_intervals(sc_obsids)
-    obsreqs = None
-    if orlist is not None:
-        obsreqs = dict([(o['obsid'], o) for o in read_or_list(orlist)])
+    obsreqs = None if orlist is None else {obs['obsid']: obs for obs in read_or_list(orlist)}
     obstemps = get_interval_data(intervals, times, ccd_temp, obsreqs)
     return json.dumps(obstemps, sort_keys=True, indent=4,
 	                  cls=NumpyAwareJSONEncoder)


### PR DESCRIPTION
Calculate the expected aca offsets using the starcheck run of the ACA model and the aimpoint information in the zero offset table of the OR list if available.