### PR TITLE
Update CCD limit to -11.5 and remove all red warnings

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -2566,11 +2566,7 @@ sub set_ccd_temps{
     $self->{n100_warm_frac} = $obsid_temps->{$self->{obsid}}->{n100_warm_frac};
     # add warnings for limit violations
     if ($self->{ccd_temp} > $config{ccd_temp_red_limit}){
-        push @{$self->{warn}}, sprintf("$alarm CCD temperature exceeds %.1f C\n",
-                                       $config{ccd_temp_red_limit});
-    }
-    elsif ($self->{ccd_temp} > $config{ccd_temp_yellow_limit}){
         push @{$self->{fyi}}, sprintf("$info CCD temperature exceeds %.1f C\n",
-                                              $config{ccd_temp_yellow_limit});
+                                       $config{ccd_temp_red_limit});
     }
 }

--- a/starcheck_data/characteristics.yaml
+++ b/starcheck_data/characteristics.yaml
@@ -60,8 +60,8 @@ no_starcat_oflsid:
    - RDE
    - DC_T
 
-ccd_temp_yellow_limit: -13.5
-ccd_temp_red_limit: -12.5
+ccd_temp_yellow_limit: -12.5
+ccd_temp_red_limit: -11.5
 
 n100_warm_frac_default: .15
 


### PR DESCRIPTION
This updates the lines in the CCD temperature plots and stops printing temperature warnings (will print an INFO statement if -11.5 is exceeded).