### PR TITLE
Fix case on search for 'Search spoiler' in warnings

### DIFF
--- a/src/lib/Ska/Starcheck/FigureOfMerit.pm
+++ b/src/lib/Ska/Starcheck/FigureOfMerit.pm
@@ -55,7 +55,7 @@ sub make_figure_of_merit{
 	if ($c->{"TYPE$i"} =~ /BOT|ACQ/) {
 	    my $mag = $c->{"GS_MAG$i"};
             my @warnings = grep {/\[\s{0,1}$i\]/} (@{$self->{warn}}, @{$self->{yellow_warn}});
-            my $spoiler = grep(/Search spoiler/, @warnings) ? 1 : 0;
+            my $spoiler = grep(/Search spoiler/i, @warnings) ? 1 : 0;
             my $color = $c->{"GS_BV$i"};
             my $hw = $c->{"HALFW$i"};
             my $star_prob = _acq_success_prob($date, $t_ccd, $mag, $color, $spoiler, $hw);

--- a/src/lib/Ska/Starcheck/FigureOfMerit.pm
+++ b/src/lib/Ska/Starcheck/FigureOfMerit.pm
@@ -55,7 +55,7 @@ sub make_figure_of_merit{
 	if ($c->{"TYPE$i"} =~ /BOT|ACQ/) {
 	    my $mag = $c->{"GS_MAG$i"};
             my @warnings = grep {/\[\s{0,1}$i\]/} (@{$self->{warn}}, @{$self->{yellow_warn}});
-            my $spoiler = grep(/Search Spoiler/, @warnings) ? 1 : 0;
+            my $spoiler = grep(/Search spoiler/, @warnings) ? 1 : 0;
             my $color = $c->{"GS_BV$i"};
             my $hw = $c->{"HALFW$i"};
             my $star_prob = _acq_success_prob($date, $t_ccd, $mag, $color, $spoiler, $hw);


### PR DESCRIPTION
Fix case on search for 'Search spoiler' in warnings.  

Incorrect case on the "s" in the regular expression to match a "Search spoiler" warning in FigureOfMerit means that the expression is never matched and all stars are assigned a spoiler status of 0.  This means that acquisition probabilities are incorrect for all stars that have spoilers (the ones already noticed by the starcheck checks for spoilers).  This PR fixes the case of the "s" in the regular expression and makes the regular expression case insensitive for good measure.  The overall impact of the change is small because SAUSAGE does not select many stars with known spoilers.
