### PR TITLE
Use mica acq stats database (hdf5) for acquisition histories

### DIFF
--- a/src/lib/Ska/Starcheck/FigureOfMerit.pm
+++ b/src/lib/Ska/Starcheck/FigureOfMerit.pm
@@ -59,6 +59,13 @@ sub make_figure_of_merit{
             my $color = $c->{"GS_BV$i"};
             my $hw = $c->{"HALFW$i"};
             my $star_prob = _acq_success_prob($date, $t_ccd, $mag, $color, $spoiler, $hw);
+            if (grep(/Bad Acquisition Star/i, @warnings)){
+                my @w = grep(/Bad Acquisition Star/i, @warnings);
+                my ($failed, $total) = parse_bad_acq_warning($w[0]);
+                if ($star_prob > (($total - $failed) / $total)){
+                    $star_prob = ($total - $failed) / $total;
+                }
+            }
 	    push @probs, $star_prob;
             $slot_probs{$c->{"IMNUM$i"}} = $star_prob;
             $c->{"P_ACQ$i"} = $star_prob;

--- a/src/lib/Ska/Starcheck/FigureOfMerit.pm
+++ b/src/lib/Ska/Starcheck/FigureOfMerit.pm
@@ -94,51 +94,6 @@ sub set_dynamic_mag_limits{
 }
 
 
-##*****************************************************************************************
-sub star_prob {
-##*****************************************************************************************
-    my ($acq) = @_;
-    my @warnings = @{ $acq->{warnings} };
-    my $mag = $acq->{magnitude};
-    my $warm_frac = $acq->{n100_warm_frac};
-
-    my $p_0p7color = .4294; #probability of acquiring a B-V = 0.700 star
-    my $p_1p5color = 0.9452; #probability of acquiring a B-V = 1.500 star
-    my $p_seaspo = .9241; #probability of acquiring a search spoiled star
-
-    my $mag10 = $mag - 10.0;
-    # Minimum warm fraction seen in fit data
-    my $warm_frac_min = 0.0412;
-    # Co-efficients from 2013 State of the ACA polynomial fit
-    my $scale = 10. ** (0.185 + 0.990 * $mag10 + -0.491 * $mag10 ** 2);
-    my $offset = 10. ** (-1.489 + 0.888 * $mag10 + 0.280 * $mag10 ** 2);
-    my $prob = 1.0 - ($offset + $scale * ($warm_frac - $warm_frac_min));
-    my $max_star_prob = .985;
-    # If the star is brighter than 8.5 or has a calculated probability
-    # higher than the $max_star_prob, clip it at that value
-    if (($mag < 8.5) or ($prob > $max_star_prob)){
-        $prob = $max_star_prob;
-    }
-
-    foreach my $warning (@warnings) {
-	if ($warning =~ /B-V = 0.700/) {
-	    $prob *= $p_0p7color;
-	}
-        if ($warning =~ /B-V = 1.500/) {
-            $prob *= $p_1p5color;
-        }
-	if ($warning =~ /Search Spoiler/) {
-	    $prob *= $p_seaspo;
-	}
-	if ($warning =~ /Bad Acquisition Star/){
-	    my ($failed, $total) = parse_bad_acq_warning($warning);
-	    $prob = ($total - $failed) / $total;
-            last;
-	}
-    }
-    return $prob;
-}
-
 
 ##*****************************************************************************************
 sub parse_bad_acq_warning {

--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -1180,8 +1180,8 @@ sub check_star_catalog {
 	my $n_obs = $bad_acqs{$sid}{n_obs};
 	    my $n_noids = $bad_acqs{$sid}{n_noids};
 	    if (defined $db_stats->{acq}){
-	        $n_obs = $db_stats->{acq};
-	        $n_noids = $db_stats->{acq_noid};
+	        $n_obs = $db_stats->{acq_5y};
+	        $n_noids = $db_stats->{acq_5ynoms_noid};
 	    }
 	    if ($n_noids && $n_obs > $obs_min_cnt && $n_noids/$n_obs > $obs_bad_frac){
 	        push @yellow_warn, sprintf 
@@ -1856,13 +1856,13 @@ sub print_report {
 	    if ($db_stats->{acq} or $db_stats->{gui}){
 	    $table .= sprintf("${idpad}<A HREF=\"%s%s\" STYLE=\"text-decoration: none;\" "
 			      . "ONMOUSEOVER=\"return overlib ('"
-			      . "ACQ total:%d noid:%d <BR />"
+			      . "ACQ total:%d noid:%d last5y:%d 5ynoidnoms:%d<BR />"
 			      . "GUI total:%d bad:%d fail:%d obc_bad:%d <BR />"
 			      . "Avg Mag %4.2f <BR />"
                               . "$acq_prob"
 			      . "', WIDTH, 220);\" ONMOUSEOUT=\"return nd();\">%s</A>", 
 			      $acq_stat_lookup, $c->{"GS_ID${i}"}, 
-			      $db_stats->{acq}, $db_stats->{acq_noid},
+			      $db_stats->{acq}, $db_stats->{acq_noid}, $db_stats->{acq_5y}, $db_stats->{acq_5ynoms_noid},
 			      $db_stats->{gui}, $db_stats->{gui_bad}, $db_stats->{gui_fail}, $db_stats->{gui_obc_bad},
 			      $db_stats->{avg_mag},
 			      $c->{"GS_ID${i}"});


### PR DESCRIPTION
Use mica acq stats database (hdf5) for acquisition histories.  

Flight starcheck is presently reading star histories from two tables in Sybase.  This PR would use the acquisition histories from the mica acq stats table (an hdf5 file) instead.  The advantage of this table for starcheck is that the mica acq stats table includes the tracked star positions with the one shot retroactively applied.   That content would let us determine if a star or a spoiler was tracked during the acquisition readout (something tracked within 5 arcsecs of intended position), and from that information, we can infer if the star "would have been" acquired for the image window *if* the image window had only had the currently-respected error flags applied (saturated pixel, ionizing radiation).  Use of this "would the star have been acquired" content will help to not "penalize" stars unfairly if previous acquisitions had the multiple star flag set due to bad pixels.

This would be the first use of the mica acq stats table in a flight/operational context.

In its current form, this PR will still not make the acquisition histories available on GRETA.
