### PR TITLE
Add warning for faint stars with big boxes

### DIFF
--- a/src/lib/Ska/Starcheck/Obsid.pm
+++ b/src/lib/Ska/Starcheck/Obsid.pm
@@ -1325,6 +1325,15 @@ sub check_star_catalog {
 	    push @warn, sprintf "$alarm [%2d] Search Box Size. Search Box smaller than slew error \n",$i;
 	}
 
+        # Double check that 180 and 160 boxes are only applied to bright stars
+        if (($type =~ /BOT|ACQ/) and ($c->{"HALFW$i"} > 160)
+            and (($mag + $c->{"GS_MAGERR$i"} * 3 / 100) > 9.2)){
+            push @warn, sprintf "$alarm [%2d] Search Box Size. Star too faint for > 160 box. \n",$i;
+        }
+        if (($type =~ /BOT|ACQ/) and ($c->{"HALFW$i"} > 120)
+            and (($mag + $c->{"GS_MAGERR$i"} * 1 / 100) > 10.2)){
+            push @warn, sprintf "$alarm [%2d] Search Box Size. Star too faint for > 120 box. \n",$i;
+        }
 
 	# Check that readout sizes are all 6x6 for science observations ACA-027
 	if ($is_science && $type =~ /BOT|GUI|ACQ/  && $c->{"SIZE$i"} ne "6x6"){


### PR DESCRIPTION
Add warning for faint stars with big boxes

SAUSAGE has been modified to allow up to 180 arcsec hw search boxes on stage 1 stars and up to 160 arcsec hw search boxes on stage 2 stars.  This change for starcheck checks that there are no search boxes greater than 120 arcsec for stars that do not satisfy the magnitude requirements for either stage 1 or stage 2, and emits a warning for exceptions to either stage check.

  - stage 1: MAG_ACA + (3 * MAG_ACA_ERR) < 9.2 mag , boxes between 160 and 180 allowed
  - stage 2: MAG_ACA + (1 * MAG_ACA_ERR) < 10.2 mag , boxes between 120 and 160 allowed

Note that MAG_ACA_ERR is in units of 0.01mag.  SAUSAGE adds error padding to MAG_ACA_ERR when determining stages, but that should only be *more* conservative than this test.