### PR TITLE
Import dark_model from chandra_aca instead of mica.archive

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -37,7 +37,7 @@ from Chandra.Time import DateTime
 import Chandra.cmd_states as cmd_states
 from Chandra.cmd_states import get_cmd_states
 import xija
-from mica.archive.aca_dark import dark_model
+from chandra_aca import dark_model
 from parse_cm import read_or_list
 from chandra_aca.drift import get_aca_offsets
 


### PR DESCRIPTION
Import dark_model from chandra_aca instead of mica.archive 

The dark_model module has been relocated to chandra_aca from mica.archive.  This PR sets starcheck's ACA model code to import from the new location (which is both the correct thing to do and will prevent future DeprecationWarnings from showing up).