### PR TITLE
Add red warn on GUI/BOT fainter than dynamic yellow limit

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1283,7 +1283,13 @@ sub check_star_catalog {
 		push @warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i,$mag;
 	    } 
 	    elsif ($mag > $self->{mag_faint_yellow}) {
-		push @yellow_warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i,$mag;
+                # Upgrade yellow mag limit violation on guide stars to red warning
+                if ($type eq 'GUI' or $type eq 'BOT'){
+                    push @warn, sprintf "$alarm [%2d] Magnitude. Guide Star %6.3f\n",$i,$mag;
+                }
+                else{
+                    push @yellow_warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i,$mag;
+                }
 	    }
 	
 	}


### PR DESCRIPTION
Add red warn on GUI/BOT fainter than dynamic yellow limit

Strictly speaking, this doesn't *add* a red warning so much as change a yellow warning to a red warning on magnitude if the IDX is for a guide or both star.  The plan here is that we want to be more conservative about picking faint stars as guide stars and would rather command no star than a faint one.
