### PR TITLE
Shorten data file printing by Starcheck_Data prefix

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -674,9 +674,15 @@ if ($mp_top_link){
 
 if (%input_files) {
     $out .= "------------  PROCESSING FILES  -----------------\n\n";
+    $out .= "DATA = $Starcheck_Data\n";
     for my $name (sort (keys %input_files)) { 
-	$out .= "Using $name file $input_files{$name}\n";
 	push @{$save_hash{files}}, $input_files{$name};
+        if ($input_files{$name} =~ /$Starcheck_Data\/?(.*)/){
+            $out .= "Using $name file DATA/$1\n";
+        }
+        else{
+            $out .= "Using $name file $input_files{$name}\n";
+        }
     };
      
 # Add info about which bad pixel file is being used:

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -678,7 +678,7 @@ if (%input_files) {
     for my $name (sort (keys %input_files)) { 
 	push @{$save_hash{files}}, $input_files{$name};
         if ($input_files{$name} =~ /$Starcheck_Data\/?(.*)/){
-            $out .= "Using $name file DATA/$1\n";
+            $out .= "Using $name file \$\{DATA\}/$1\n";
         }
         else{
             $out .= "Using $name file $input_files{$name}\n";


### PR DESCRIPTION
Shorten data file printing by Starcheck_Data prefix

The new python packaging puts the data files in long paths
```
Using bad_pixel file /data/fido/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/starcheck/data/ACABadPixels
```

This patch just puts that path once at the top of the file list and replaces the other entries with the text DATA

```
DATA = /data/fido/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/starcheck/data/
Using bad_pixel file DATA/ACABadPixels
```