### PR TITLE
Add end of maneuver date/time to output for obsid

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1813,9 +1813,10 @@ sub print_report {
 	    $o .= sprintf "MP_TARGQUAT at $c->{date} (VCDU count = $c->{vcdu})\n";
 	    $o .= sprintf("  Q1,Q2,Q3,Q4: %.8f  %.8f  %.8f  %.8f\n", $c->{Q1}, $c->{Q2}, $c->{Q3}, $c->{Q4});
 	    if (exists $c->{man_err} and exists $c->{dur} and exists $c->{angle}){
-		$o .= sprintf("  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f arcsec\n",
-			      $c->{angle}, $c->{dur}, $c->{man_err})
+		$o .= sprintf("  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f\n",
+			      $c->{angle}, $c->{dur}, $c->{man_err});
 		}
+            $o .= sprintf("  MANVR: Ends= %s\n", time2date($c->{tstop}));
 	    $o .= "\n";
 	}
     }
@@ -1832,7 +1833,7 @@ sub print_report {
 	my @star_fields = qw (   TYPE  SIZE P_ACQ GS_MAG MAXMAG YANG ZANG DIMDTS RESTRK HALFW GS_PASS GS_NOTES);
 	my @star_format = ( '%6s',   '%5s',  '%8.3f',    '%8s',  '%8.3f',  '%7d',  '%7d',    '%4d',    '%4d',   '%5d',     '%6s',  '%4s');
 
-	$table.= sprintf "MP_STARCAT at $c->{date} (VCDU count = $c->{vcdu}) NPM starts %s\n", time2date($self->{obs_tstart});
+	$table.= sprintf "MP_STARCAT at $c->{date} (VCDU count = $c->{vcdu})\n";
 	$table.= sprintf "---------------------------------------------------------------------------------------------\n";
 	$table.= sprintf " IDX SLOT        ID  TYPE   SZ   P_ACQ    MAG   MAXMAG   YANG   ZANG DIM RES HALFW PASS NOTES\n";
 #                      [ 4]  3   971113176   GUI  6x6   1.000   7.314   8.844  -2329  -2242   1   1   25  bcmp

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1832,7 +1832,7 @@ sub print_report {
 	my @star_fields = qw (   TYPE  SIZE P_ACQ GS_MAG MAXMAG YANG ZANG DIMDTS RESTRK HALFW GS_PASS GS_NOTES);
 	my @star_format = ( '%6s',   '%5s',  '%8.3f',    '%8s',  '%8.3f',  '%7d',  '%7d',    '%4d',    '%4d',   '%5d',     '%6s',  '%4s');
 
-	$table.= sprintf "MP_STARCAT at $c->{date} (VCDU count = $c->{vcdu})\n";
+	$table.= sprintf "MP_STARCAT at $c->{date} (VCDU count = $c->{vcdu}) NPM starts %s\n", time2date($self->{obs_tstart});
 	$table.= sprintf "---------------------------------------------------------------------------------------------\n";
 	$table.= sprintf " IDX SLOT        ID  TYPE   SZ   P_ACQ    MAG   MAXMAG   YANG   ZANG DIM RES HALFW PASS NOTES\n";
 #                      [ 4]  3   971113176   GUI  6x6   1.000   7.314   8.844  -2329  -2242   1   1   25  bcmp

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1813,10 +1813,9 @@ sub print_report {
 	    $o .= sprintf "MP_TARGQUAT at $c->{date} (VCDU count = $c->{vcdu})\n";
 	    $o .= sprintf("  Q1,Q2,Q3,Q4: %.8f  %.8f  %.8f  %.8f\n", $c->{Q1}, $c->{Q2}, $c->{Q3}, $c->{Q4});
 	    if (exists $c->{man_err} and exists $c->{dur} and exists $c->{angle}){
-		$o .= sprintf("  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f\n",
-			      $c->{angle}, $c->{dur}, $c->{man_err});
+		$o .= sprintf("  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f  End= %s\n",
+			      $c->{angle}, $c->{dur}, $c->{man_err}, substr(time2date($c->{tstop}), 0, 17));
 		}
-            $o .= sprintf("  MANVR: Ends= %s\n", time2date($c->{tstop}));
 	    $o .= "\n";
 	}
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1813,7 +1813,7 @@ sub print_report {
 	    $o .= sprintf "MP_TARGQUAT at $c->{date} (VCDU count = $c->{vcdu})\n";
 	    $o .= sprintf("  Q1,Q2,Q3,Q4: %.8f  %.8f  %.8f  %.8f\n", $c->{Q1}, $c->{Q2}, $c->{Q3}, $c->{Q4});
 	    if (exists $c->{man_err} and exists $c->{dur} and exists $c->{angle}){
-		$o .= sprintf("  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f  End= %s\n",
+		$o .= sprintf("  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f arcsec  End= %s\n",
 			      $c->{angle}, $c->{dur}, $c->{man_err}, substr(time2date($c->{tstop}), 0, 17));
 		}
 	    $o .= "\n";


### PR DESCRIPTION
Add end of maneuver date/time to output for obsid

These are the commits that were approved and merged as #190 , but it looks like *this* is exactly where my accidental force push to master overwrote the record of that merge ever happening.  Redoing the PR seems the best way to proceed.
