### PR TITLE
Make 10.3 guide warning independent of other mag warnings

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1279,12 +1279,12 @@ sub check_star_catalog {
 	# Faint and bright limits ~ACA-009 ACA-010
 	if ($type ne 'MON' and $mag ne '---') {
 
+            if (($type eq 'GUI' or $type eq 'BOT') and $mag > 10.3){
+		push @warn, sprintf "$alarm [%2d] Magnitude. Guide star %6.3f\n",$i,$mag;
+            }
 	    if ($mag < $mag_bright or $mag > $self->{mag_faint_red}) {
 		push @warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i,$mag;
 	    }
-            elsif (($type eq 'GUI' or $type eq 'BOT') and $mag > 10.3){
-		push @warn, sprintf "$alarm [%2d] Magnitude. Guide star %6.3f\n",$i,$mag;
-            }
 	    elsif ($mag > $self->{mag_faint_yellow}) {
 		push @yellow_warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i,$mag;
 	    }


### PR DESCRIPTION
The added warning for 10.3 guide stars was  .. usurped by a generic red warning on the slot if the star is fainter than the acq red limit.  This change just changes the elsif so they both print for a BOT star:

![old_output](https://cloud.githubusercontent.com/assets/791508/25817853/a0c115a2-33f6-11e7-8910-4dbf99fbdec6.png)

![new_output](https://cloud.githubusercontent.com/assets/791508/25817861/a7f775be-33f6-11e7-8232-80aff9e66018.png)






