### PR TITLE
Update version to 11.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ RELATED_LIB = $(SRC)/StarcheckParser.pm
 BIN = $(SRC)/starcheck.pl $(SRC)/starcheck
 LIB = $(SRC)/lib/Ska/Starcheck/Obsid.pm $(SRC)/lib/Ska/Starcheck/FigureOfMerit.pm \
 	$(SRC)/lib/Ska/Starcheck/Dark_Cal_Checker.pm $(SRC)/lib/Ska/Parse_CM_File.pm
-PYTHON_LIB = starcheck/calc_ccd_temps.py starcheck/pcad_att_check.py
+PYTHON_LIB = starcheck/calc_ccd_temps.py starcheck/pcad_att_check.py starcheck/plot.py \
+             starcheck/version.py starcheck/__init__.py
 DOC_RST = $(SRC)/aca_load_review_cl.rst
 DOC_HTML = aca_load_review_cl.html
 

--- a/starcheck/version.py
+++ b/starcheck/version.py
@@ -14,7 +14,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '11.17'
+version = '11.18'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])


### PR DESCRIPTION
Update starcheck to version 11.18

This release is only to include use of the updated chandra_aca.plot routine which now works in row/col instead of yag/zag.  The plots are still labeled in yag/zag.