### PR TITLE
Update red/planning limit to -10.9C

### DIFF
--- a/starcheck/data/characteristics.yaml
+++ b/starcheck/data/characteristics.yaml
@@ -60,8 +60,8 @@ no_starcat_oflsid:
    - RDE
    - DC_T
 
-ccd_temp_yellow_limit: -12.5
-ccd_temp_red_limit: -11.5
+ccd_temp_yellow_limit: -11.9
+ccd_temp_red_limit: -10.9
 
 n100_warm_frac_default: .15
 


### PR DESCRIPTION
Update red/planning limit to -10.9 C.  This is used for the lines in the top plot and for applying a blue "warning" to obsids that have temperatures that exceed the limit.  

The yellow limit is also used on the plot but could probably be removed.

