### PR TITLE
Reorganize dither checking (mostly for ERs)

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1807,9 +1807,11 @@ sub print_report {
     if ( defined $self->{cmd_dither_status} ) {
 	$o .= sprintf "Dither: %-3s ",$self->{cmd_dither_status};
 	$o .= sprintf ("Y_amp=%4.1f  Z_amp=%4.1f  Y_period=%6.1f  Z_period=%6.1f",
-		       $self->{cmd_dither_y_amp}*3600., $self->{cmd_dither_z_amp}*3600.,
+		       $self->{cmd_dither_y_amp}, $self->{cmd_dither_z_amp},
 		       $self->{cmd_dither_y_period}, $self->{cmd_dither_z_period})
         if ($self->{cmd_dither_status} eq 'ENAB' && $self->{cmd_dither_y_period} && $self->{cmd_dither_z_period});
+	$o .= sprintf ("(no commanded dither amp: checked with 20 arcsec dither)")
+        if ($self->{cmd_dither_status} eq 'ENAB' && not(defined $self->{cmd_dither_y_period}));
 	$o .= "\n";
     }
 


### PR DESCRIPTION
We changed to using only commanded dither (from backstop) to check dither and catalogs for observations.  However, the code that was supposed to *set* the values of the commanded dither for each obsid object was not actually run for ERs.  Basically, setting the values was a side effect of dither checking code that wasn't run on ERs.

This PR both lets that dither checking code do some checks that could actually apply to ERs and lets that "side effect" work, appropriately setting the commanded dither for ERs.

Before this PR (but after the use-only-commanded-dither change), ERs were just being checked with default 20 arcsec dither.  They are still checked with 20 arcsec dither if placed in the schedule before any dither commanding (no commanded dither available).

This PR also prints dither info for ERs in the starcheck report and adds a comment when the dither values being used for checking are just the 20 arcsec amplitude default values.

Closes #247.