### PR TITLE
Improve summary

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Dark_Cal_Checker.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Dark_Cal_Checker.pm
@@ -111,6 +111,7 @@ sub new{
     $feedback{check_dwell} = check_dwell(\%config, $manvrs, $dwells);
     $feedback{check_manvr_point} = check_manvr_point( \%config, \@bs, $manvrs);
     $feedback{check_momentum_unloads} = check_momentum_unloads(\%config, \@bs, $manvrs, $dwells);
+    $feedback{dc_oflsid} = \%dc_oflsid;
 	
     bless \%feedback, $class;
     return \%feedback;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2532,7 +2532,8 @@ sub count_guide_stars{
     for my $i (1 .. 16){
 	if ($c->{"TYPE$i"} =~ /GUI|BOT/){
             my $mag = $c->{"GS_MAG$i"};
-            # Use the fractional magnitudes from ORViewer.  tab-ternary is if/elsif/else
+            # Compute fractional guide star count using magnitude bins and fractions
+            # defined in ORViewer. (Note tab-ternary is if/elsif/else)
             my $star_contrib = $mag <= 10.0  ? 1.0
                              : $mag <= 10.2  ? 0.5
                              : $mag <= 10.3  ? 0.75

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2533,10 +2533,10 @@ sub count_guide_stars{
 	if ($c->{"TYPE$i"} =~ /GUI|BOT/){
             my $mag = $c->{"GS_MAG$i"};
             # Use the fractional magnitudes from ORViewer.  tab-ternary is if/elsif/else
-            my $star_contrib = $mag <= 10.0  ? 1
-                             : $mag <= 10.2  ?  .5
-                             : $mag <= 10.3  ?  .75
-                             :                 0;
+            my $star_contrib = $mag <= 10.0  ? 1.0
+                             : $mag <= 10.2  ? 0.5
+                             : $mag <= 10.3  ? 0.75
+                             :                 0.0;
             $gui_count += $star_contrib;
 	}
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1058,7 +1058,6 @@ sub check_star_catalog {
 
     my $mag_faint_slot_diff = 1.4; # used in slot test like:
                                    # $c->{"MAXMAG$i"} - $c->{"GS_MAG$i"} >= $mag_faint_slot_diff
-    my $mag_bright      = 6.0;	# Bright mag limit 
 
     my $fid_faint = 7.2;
     my $fid_bright = 6.8;
@@ -1277,20 +1276,34 @@ sub check_star_catalog {
 	push @yellow_warn, sprintf "$alarm [%2d] Quadrant Boundary. \n",$i 
 	    unless ($type eq 'ACQ' or $type eq 'MON' or 
 		    (abs($yag-$y0) > $qb_dist + $slot_dither and abs($zag-$z0) > $qb_dist + $slot_dither ));
-	
-	# Faint and bright limits ~ACA-009 ACA-010
-	if ($type ne 'MON' and $mag ne '---') {
 
-            if (($type eq 'GUI' or $type eq 'BOT') and $mag > 10.3){
-		push @warn, sprintf "$alarm [%2d] Magnitude. Guide star %6.3f\n",$i,$mag;
+	# Faint and bright limits ~ACA-009 ACA-010
+	if ($mag ne '---') {
+            if ($type eq 'GUI' or $type eq 'BOT'){
+                my $guide_mag_warn = sprintf "$alarm [%2d] Magnitude. Guide star %6.3f\n", $i, $mag;
+                if (($mag > 10.3) or ($mag < 6.0)){
+                    push @warn, $guide_mag_warn;
+                }
+                elsif ($mag > 10.2){
+                    push @orange_warn, $guide_mag_warn;
+                }
+                elsif ($mag > 10.0){
+                    push @yellow_warn, $guide_mag_warn;
+                }
+
             }
-	    if ($mag < $mag_bright or $mag > $self->{mag_faint_red}) {
-		push @warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i,$mag;
-	    }
-	    elsif ($mag > $self->{mag_faint_yellow}) {
-		push @yellow_warn, sprintf "$alarm [%2d] Magnitude.  %6.3f\n",$i,$mag;
-	    }
-	
+            if ($type eq 'BOT' or $type eq ' ACQ'){
+                my $acq_mag_warn = sprintf "$alarm [%2d] Magnitude. Acq star %6.3f\n", $i, $mag;
+                if ($mag < 5.8){
+                    push @warn, $acq_mag_warn;
+                }
+                elsif ($mag > $self->{mag_faint_red}){
+                    push @orange_warn, $acq_mag_warn;
+                }
+                elsif ($mag > $self->{mag_faint_yellow}){
+                    push @yellow_warn, $acq_mag_warn;
+                }
+            }
 	}
 
 	# FID magnitude limits ACA-011

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -53,7 +53,7 @@ my %Default_SIM_Z = ('ACIS-I' => 92905,
 		     'HRC-S'  => -99612);
 
 my $font_stop = qq{</font>};
-my ($red_font_start, $blue_font_start, $yellow_font_start);
+my ($red_font_start, $blue_font_start, $orange_font_start, $yellow_font_start);
 
 my $ID_DIST_LIMIT = 1.5;		# 1.5 arcsec box for ID'ing a star
 
@@ -82,6 +82,7 @@ sub new {
     $self->{date}  = shift;
     $self->{dot_obsid} = $self->{obsid};
     @{$self->{warn}} = ();
+    @{$self->{orange_warn}} = ();
     @{$self->{yellow_warn}} = ();
     @{$self->{fyi}} = ();
     $self->{n_guide_summ} = 0;
@@ -108,6 +109,7 @@ sub setcolors {
     $red_font_start = $colorref->{red};
     $blue_font_start = $colorref->{blue};
     $yellow_font_start = $colorref->{yellow};
+    $orange_font_start = $colorref->{orange};
 }
 
 
@@ -1090,6 +1092,7 @@ sub check_star_catalog {
     }
 
     my @warn = ();
+    my @orange_warn = ();
     my @yellow_warn = ();
 
     my $oflsid = $self->{dot_obsid};
@@ -1445,6 +1448,7 @@ sub check_star_catalog {
 
     # Collect warnings
     push @{$self->{warn}}, @warn;
+    push @{$self->{orange_warn}}, @orange_warn;
     push @{$self->{yellow_warn}}, @yellow_warn;
 }
 
@@ -1983,6 +1987,13 @@ sub print_report {
     if (@{$self->{warn}}) {
 	$o .= "${red_font_start}";
 	foreach (@{$self->{warn}}) {
+	    $o .= $_;
+	}
+	$o .= "${font_stop}";
+    }
+    if (@{$self->{orange_warn}}) {
+	$o .= "${orange_font_start}";
+	foreach (@{$self->{orange_warn}}) {
 	    $o .= $_;
 	}
 	$o .= "${font_stop}";

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2519,9 +2519,9 @@ sub count_guide_stars{
 ###################################################################################
     my $self=shift;
     my $c;
-    my $gui_count = 0;
+    my $gui_count = 0.0;
 
-    return unless ($c = find_command($self, 'MP_STARCAT'));
+    return 0.0 unless ($c = find_command($self, 'MP_STARCAT'));
     for my $i (1 .. 16){
 	if ($c->{"TYPE$i"} =~ /GUI|BOT/){
             my $mag = $c->{"GS_MAG$i"};

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1284,13 +1284,6 @@ sub check_star_catalog {
                 if (($mag > 10.3) or ($mag < 6.0)){
                     push @warn, $guide_mag_warn;
                 }
-                elsif ($mag > 10.2){
-                    push @orange_warn, $guide_mag_warn;
-                }
-                elsif ($mag > 10.0){
-                    push @yellow_warn, $guide_mag_warn;
-                }
-
             }
             if ($type eq 'BOT' or $type eq ' ACQ'){
                 my $acq_mag_warn = sprintf "$alarm [%2d] Magnitude. Acq star %6.3f\n", $i, $mag;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1240,7 +1240,7 @@ sub check_star_catalog {
             # for all others, including (B-V = 1.5 and guide), yellow warning
             if ( $marginal_note ){
                 if ($color eq '0.7000000' && $type =~ /BOT|GUI/ ) { 
-                    push @warn, $marginal_note;
+                    push @orange_warn, $marginal_note;
                 }
                 else{
                     push @yellow_warn, $marginal_note;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2528,8 +2528,8 @@ sub count_guide_stars{
             # Compute fractional guide star count using magnitude bins and fractions
             # defined in ORViewer. (Note tab-ternary is if/elsif/else)
             my $star_contrib = $mag <= 10.0  ? 1.0
-                             : $mag <= 10.2  ? 0.5
-                             : $mag <= 10.3  ? 0.75
+                             : $mag <= 10.2  ? 0.75
+                             : $mag <= 10.3  ? 0.5
                              :                 0.0;
             $gui_count += $star_contrib;
 	}

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2503,9 +2503,7 @@ sub count_good_stars{
 ###################################################################################
     my $self=shift;
     my $c;
-    my $clean_acq_count = 0;
     my $clean_gui_count = 0;
-    $self->{count_nowarn_stars}{ACQ} = $clean_acq_count;
     $self->{count_nowarn_stars}{GUI} = $clean_gui_count;
 
     return unless ($c = find_command($self, 'MP_STARCAT'));
@@ -2513,11 +2511,6 @@ sub count_good_stars{
         my $type = $c->{"TYPE$i"};
         next if ($type eq 'NUL');
         next if ($type eq 'FID');
-	if ($type =~ /ACQ|BOT/){
-	    unless ($self->check_idx_warn($i)){
-		$clean_acq_count++;
-	    }
-	}
 	if ($type =~ /GUI|BOT/){
 	    unless ($self->check_idx_warn($i)){
 		$clean_gui_count++;
@@ -2525,7 +2518,6 @@ sub count_good_stars{
 	}
 	
     }
-    $self->{count_nowarn_stars}{ACQ} = $clean_acq_count;
     $self->{count_nowarn_stars}{GUI} = $clean_gui_count;
 
 }

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -816,7 +816,7 @@ for my $obs_idx (0 .. $#obsid_id) {
         : $empty_font_start;
 
         $out .= "$acq_font_start";
-        $out .= sprintf("%3.1f  ACQ | ", $obs{$obsid}->{figure_of_merit}->{expected});
+        $out .= sprintf("%3.1f ACQ | ", $obs{$obsid}->{figure_of_merit}->{expected});
         $out .= "$font_stop";
 
         $out .= "$gui_font_start";

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -124,6 +124,7 @@ my $STARCHECK   = $par{out} || ($par{vehicle} ? 'v_starcheck' : 'starcheck');
 
 my $empty_font_start = qq{<font>};
 my $red_font_start = qq{<font color="#FF0000">};
+my $orange_font_start = qq{<font color="#ff6400">};
 my $yellow_font_start = qq{<font color="#009900">};
 my $blue_font_start = qq{<font color="#0000FF">};
 my $font_stop = qq{</font>};
@@ -341,7 +342,8 @@ if ($dot_touched_by_sausage == 0 ){
 
 Ska::Starcheck::Obsid::setcolors({ red => $red_font_start,
 				   blue => $blue_font_start,
-				   yellow => $yellow_font_start, 
+				   yellow => $yellow_font_start,
+                                   orange => $orange_font_start,
 				   });
 
 my %odb = Ska::Parse_CM_File::odb($odb_file);
@@ -831,11 +833,15 @@ for my $obs_idx (0 .. $#obsid_id) {
 
     if (@{$obs{$obsid}->{warn}}) {
 	my $count_red_warn = $#{$obs{$obsid}->{warn}}+1;
-	$out .= sprintf("${red_font_start}WARNINGS [%2d]${font_stop} ", $count_red_warn);
-    } 
+	$out .= sprintf("${red_font_start}Critical:%2d${font_stop} ", $count_red_warn);
+    }
+    if (@{$obs{$obsid}->{orange_warn}}) {
+	my $count_orange_warn = $#{$obs{$obsid}->{orange_warn}}+1;
+	$out .= sprintf("${orange_font_start}Warn:%2d${font_stop} ", $count_orange_warn);
+    }
     if (@{$obs{$obsid}->{yellow_warn}}) {
 	my $count_yellow_warn = $#{$obs{$obsid}->{yellow_warn}}+1;
-	$out .= sprintf("${yellow_font_start}WARNINGS [%2d]${font_stop}", $count_yellow_warn);
+	$out .= sprintf("${yellow_font_start}Caution:%2d${font_stop}", $count_yellow_warn);
     }
     $out .= "\n";
 }

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -810,13 +810,22 @@ for my $obs_idx (0 .. $#obsid_id) {
             $min_num_gui = 4.0;
         }
 
-        my $acq_font_start = $obs{$obsid}->{figure_of_merit}->{cum_prob_bad} ? $red_font_start
+        # Use the acq prob model values saved in figure_of_merit for the expected
+        # number of acq stars and a bad overall probability.  figure_of_merit isn't
+        # defined if there is no star catalog, so use default of 0 stars and not-bad (0 status)
+        my $n_acq = 0.0;
+        my $bad_acq_prob = 0;
+        if (defined $obs{$obsid}->{figure_of_merit}){
+            $n_acq = $obs{$obsid}->{figure_of_merit}->{expected};
+            $bad_acq_prob = $obs{$obsid}->{figure_of_merit}->{cum_prob_bad};
+        }
+        my $acq_font_start =  $bad_acq_prob ? $red_font_start
         : $empty_font_start;
         my $gui_font_start = ($guide_count < $min_num_gui) ? $red_font_start
         : $empty_font_start;
 
         $out .= "$acq_font_start";
-        $out .= sprintf("%3.1f ACQ | ", $obs{$obsid}->{figure_of_merit}->{expected});
+        $out .= sprintf("%3.1f ACQ | ", $n_acq);
         $out .= "$font_stop";
 
         $out .= "$gui_font_start";

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -627,7 +627,6 @@ foreach my $obsid (@obsid_id) {
 	$obs{$obsid}->check_momentum_unload(\@bs);
     $obs{$obsid}->check_for_special_case_er();
     $obs{$obsid}->check_bright_perigee($radmon);
-    $obs{$obsid}->count_good_stars();
     # Start check for big boxes at FEB1317 (which gets test products but no regress products)
     if ($bs[0]->{time} > date2time('2017:043:00:00:00.000')){
         $obs{$obsid}->check_big_box_stars();
@@ -790,7 +789,7 @@ for my $obs_idx (0 .. $#obsid_id) {
     $out .= sprintf "<A HREF=\"#obsid$obs{$obsid}->{obsid}\">OBSID = %5s</A>", $obs{$obsid}->{obsid};
     $out .= sprintf " at $obs{$obsid}->{date}   ";
 
-    my $good_guide_count = $obs{$obsid}->{count_nowarn_stars}{GUI};
+    my $guide_count = $obs{$obsid}->count_guide_stars();
 
     # if Obsid is numeric, print tally info
     if ($obs{$obsid}->{obsid} =~ /^\d+$/ ){
@@ -812,7 +811,7 @@ for my $obs_idx (0 .. $#obsid_id) {
 
         my $acq_font_start = $obs{$obsid}->{figure_of_merit}->{cum_prob_bad} ? $red_font_start
         : $empty_font_start;
-        my $gui_font_start = ($good_guide_count < $min_num_gui) ? $red_font_start
+        my $gui_font_start = ($guide_count < $min_num_gui) ? $red_font_start
         : $empty_font_start;
 
         $out .= "$acq_font_start";
@@ -820,7 +819,7 @@ for my $obs_idx (0 .. $#obsid_id) {
         $out .= "$font_stop";
 
         $out .= "$gui_font_start";
-        $out .= sprintf "$good_guide_count clean GUI | ";
+        $out .= sprintf("%3.1f GUI | ", $guide_count);
         $out .= "$font_stop";
 	
     }

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -351,6 +351,16 @@ Ska::Starcheck::Obsid::set_odb(%odb);
 
 
 Ska::Starcheck::Obsid::set_config($config_ref);
+# If there is a dark current, add the obsids of the dark cal replicas
+# (which have keys beginning with "DC_T") to the set of obsids/oflsids
+# that are "ok" to not have star catalogs
+if ($dark_cal_checker->{dark_cal_present}){
+    foreach my $key (keys %{$dark_cal_checker->{dc_oflsid}}){
+        if ($key =~ /DC_T/){
+            push @{$config_ref->{no_starcat_oflsid}}, $dark_cal_checker->{dc_oflsid}->{$key};
+        }
+    }
+}
 
 # Set the multple star filter disabled in the model if after this date
 my $MSF_ENABLED = $bs[0]->{date} lt '2016:102:00:00:00.000';

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -791,36 +791,32 @@ for my $obs_idx (0 .. $#obsid_id) {
     $out .= sprintf " at $obs{$obsid}->{date}   ";
 
     my $good_guide_count = $obs{$obsid}->{count_nowarn_stars}{GUI};
-    my $good_acq_count = $obs{$obsid}->{count_nowarn_stars}{ACQ};
 
     # if Obsid is numeric, print tally info
     if ($obs{$obsid}->{obsid} =~ /^\d+$/ ){
 
         # minumum requirements for acq and guide for ERs and ORs
         # should be set by config...
-        my $min_num_acq = ($obs{$obsid}->{obsid} >= 38000 ) ? 5 : 4;
         my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000 ) ? 6 : 4;
 
         # if there is no star catalog and that's ok
         if (not ($obs{$obsid}->find_command("MP_STARCAT"))
-            and $obs{$obsid}->{ok_no_starcat}){
-            $min_num_acq = 0;
+                and $obs{$obsid}->{ok_no_starcat}){
             $min_num_gui = 0;
         }
 
         # use the 'special case' ER rules from ACA-044
         if ($obs{$obsid}->{special_case_er}){
-            $min_num_acq = 4;
             $min_num_gui = 4;
         }
 
-        my $acq_font_start = ($good_acq_count < $min_num_acq) ? $red_font_start
+        my $acq_font_start = $obs{$obsid}->{figure_of_merit}->{cum_prob_bad} ? $red_font_start
         : $empty_font_start;
         my $gui_font_start = ($good_guide_count < $min_num_gui) ? $red_font_start
         : $empty_font_start;
 
         $out .= "$acq_font_start";
-        $out .= sprintf "$good_acq_count clean ACQ | ";
+        $out .= sprintf("%3.1f  ACQ | ", $obs{$obsid}->{figure_of_merit}->{expected});
         $out .= "$font_stop";
 
         $out .= "$gui_font_start";

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -796,19 +796,18 @@ for my $obs_idx (0 .. $#obsid_id) {
     # if Obsid is numeric, print tally info
     if ($obs{$obsid}->{obsid} =~ /^\d+$/ ){
 
-        # minumum requirements for acq and guide for ERs and ORs
-        # should be set by config...
-        my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000 ) ? 6 : 4;
+        # minumum requirements for fractional guide star count for ERs and ORs
+        my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000 ) ? 6.0 : 4.0;
 
         # if there is no star catalog and that's ok
         if (not ($obs{$obsid}->find_command("MP_STARCAT"))
                 and $obs{$obsid}->{ok_no_starcat}){
-            $min_num_gui = 0;
+            $min_num_gui = 0.0;
         }
 
         # use the 'special case' ER rules from ACA-044
         if ($obs{$obsid}->{special_case_er}){
-            $min_num_gui = 4;
+            $min_num_gui = 4.0;
         }
 
         my $acq_font_start = $obs{$obsid}->{figure_of_merit}->{cum_prob_bad} ? $red_font_start


### PR DESCRIPTION
This change:
   * replaces the number of "clean" acq stars with the number of estimated acquisition stars from the probability model.  The estimate is printed in red if the acquisition probability (not printed in summary) is below the threshold.
   * replaces the number of "clean" gui star with the fractional count using the mag bins and fractions from ORViewer
   * demotes some warnings to a new orange class of warnings