### PR TITLE
Do bad pixel checks for all guide stars

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1374,7 +1374,7 @@ sub check_star_catalog {
 	# Bad Pixels ACA-025
         my @close_pixels;
         my @dr;
-	if ($type ne 'ACQ' and $c->{"GS_PASS$i"} =~ /^1|\s+|g[1-2]/) {
+        if ($type =~ /GUI|BOT/){
 	    foreach my $pixel (@bad_pixels) {
 		my $dy = abs($yag-$pixel->{yag});
 		my $dz = abs($zag-$pixel->{zag});


### PR DESCRIPTION
This changes the bad pixel check from working only on first and second stage guide stars to all guide stars.  