### PR TITLE
Assign red warning to guide star with bad history

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1208,7 +1208,7 @@ sub check_star_catalog {
 	        $n_nbad = $db_stats->{gui_bad};
 	    }
 	    if ($n_nbad && $n_obs > $obs_min_cnt && $n_nbad/$n_obs > $obs_bad_frac){
-	        push @yellow_warn, sprintf 
+	        push @warn, sprintf
 		"$alarm [%2d] Bad Guide Star. %s has bad data %2d of %2d attempts\n",
 		$i, $sid, $n_nbad, $n_obs;
 	    }


### PR DESCRIPTION
This is presently set to call the status in a previous observation "bad" if not tracked for more than 5% of an observation.