### PR TITLE
Rearrange star color and class warnings 

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1249,7 +1249,15 @@ sub check_star_catalog {
                     push @yellow_warn, $marginal_note;
                 }
             }
-	    push @warn, sprintf("$alarm [%2d] Bad star.  Class = %s %s\n", $i,$c->{"GS_CLASS$i"},$note) if ($c->{"GS_NOTES$i"} =~ /b/);
+            # If a star and bad class, print the bad star warning
+            if ($c->{"GS_CLASS$i"} != 0){
+                if ($type =~ /BOT|GUI|ACQ/ ){
+                    push @warn, sprintf("$alarm [%2d] Bad star.  Class = %s %s\n", $i,$c->{"GS_CLASS$i"},$note);
+                }
+                elsif ($type eq 'MON'){
+                    push @{$self->{fyi}}, sprintf("$info [%2d] MON class= %s %s (do not convert to GUI)\n", $i,$c->{"GS_CLASS$i"},$note);
+                }
+            }
 	}
 
 	# Star/fid outside of CCD boundaries

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1239,8 +1239,8 @@ sub check_star_catalog {
                             $c->{"GS_BV$i"}, ($c->{"GS_MAGERR$i"})/100, ($c->{"GS_POSERR$i"})/1000)
                 if ($c->{"GS_NOTES$i"} =~ /[Ccmp]/);
 	    $marginal_note = sprintf("$alarm [%2d] Marginal star. %s\n",$i,$note) if ($c->{"GS_NOTES$i"} =~ /[^b]/);
-            # for B-V = 0.7 and orange warnings
-            # for all others, including (B-V = 1.5), yellow warning
+            # Assign orange warnings to catalog stars with B-V = 0.7 .
+            # Assign yellow warnings to catalog stars with other issues (example B-V = 1.5).
             if (($marginal_note) && ($type =~ /BOT|GUI|ACQ/)) {
                 if ($color eq '0.7000000'){
                     push @orange_warn, $marginal_note;
@@ -1249,7 +1249,7 @@ sub check_star_catalog {
                     push @yellow_warn, $marginal_note;
                 }
             }
-            # If a star and bad class, print the bad star warning
+            # Print bad star warning on catalog stars with bad class.
             if ($c->{"GS_CLASS$i"} != 0){
                 if ($type =~ /BOT|GUI|ACQ/ ){
                     push @warn, sprintf("$alarm [%2d] Bad star.  Class = %s %s\n", $i,$c->{"GS_CLASS$i"},$note);

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1239,10 +1239,10 @@ sub check_star_catalog {
                             $c->{"GS_BV$i"}, ($c->{"GS_MAGERR$i"})/100, ($c->{"GS_POSERR$i"})/1000)
                 if ($c->{"GS_NOTES$i"} =~ /[Ccmp]/);
 	    $marginal_note = sprintf("$alarm [%2d] Marginal star. %s\n",$i,$note) if ($c->{"GS_NOTES$i"} =~ /[^b]/);
-            # for B-V = 0.7 and guide, red warnings
-            # for all others, including (B-V = 1.5 and guide), yellow warning
-            if ( $marginal_note ){
-                if ($color eq '0.7000000' && $type =~ /BOT|GUI/ ) { 
+            # for B-V = 0.7 and orange warnings
+            # for all others, including (B-V = 1.5), yellow warning
+            if (($marginal_note) && ($type =~ /BOT|GUI|ACQ/)) {
+                if ($color eq '0.7000000'){
                     push @orange_warn, $marginal_note;
                 }
                 else{

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1232,7 +1232,7 @@ sub check_star_catalog {
 	    # ignore precision errors in color
 	    my $color = sprintf('%.7f', $c->{"GS_BV$i"});
 	    $c->{"GS_NOTES$i"} .= 'c' if ($color eq '0.7000000'); # ACA-033
-            $c->{"GS_NOTES$i"} .= 'C' if ($color eq '1.5000000') && ($mag > 10.0);
+            $c->{"GS_NOTES$i"} .= 'C' if ($color eq '1.5000000');
 	    $c->{"GS_NOTES$i"} .= 'm' if ($c->{"GS_MAGERR$i"} > 99);
 	    $c->{"GS_NOTES$i"} .= 'p' if ($c->{"GS_POSERR$i"} > 399);
 	    $note = sprintf("B-V = %.3f, Mag_Err = %.2f, Pos_Err = %.2f",


### PR DESCRIPTION
Rearrange star color and class warnings.
   * remove filter on color 1.5 stars that only included label and warning if star fainter than 10th mag
   * add orange warning for acq stars with color 0.700
   * remove class and color warnings on monitor windows and add info statement