### PR TITLE
Remove quadrant boundary checks

### DIFF
--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -241,10 +241,6 @@ Checks
 |ACA-011|Magnitude limit   |X|X|FL: 6.8 - 7.2                              |n/a |Reduced aspect  |
 |       |                  | | |                                           |    |quality         |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
-|       |CCD quadrant inner|X|X|                                           |    |Possible Bright |
-|ACA-012|boundary exclusion| | |AS: n/a                                    |n/a |Star Hold       |
-|       |zones             | | |                                           |    |                |
-+-------+------------------+-+-+-------------------------------------------+----+----------------+
 |ACA-015|Search box size   |X|X|AS: Half-width (arcsec)                    |n/a |Possible Bright |
 |       |                  | | |       >= maneuver uncertainty             |    |Star Hold       |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+

--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -245,14 +245,6 @@ Checks
 |ACA-012|boundary exclusion| | |AS: n/a                                    |n/a |Star Hold       |
 |       |zones             | | |                                           |    |                |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
-|       |CCD quadrant inner|X|X|                                           |    |Reduced aspect  |
-|ACA-013|boundary exclusion| | |GS: (dither + 20) arcsec                   |n/a |quality         |
-|       |zones             | | |                                           |    |                |
-+-------+------------------+-+-+-------------------------------------------+----+----------------+
-|       |CCD quadrant inner|X|X|                                           |    |Reduced aspect  |
-|ACA-014|boundary exclusion| | |FL: 25 arcsec                              |n/a |quality         |
-|       |zones             | | |                                           |    |                |
-+-------+------------------+-+-+-------------------------------------------+----+----------------+
 |ACA-015|Search box size   |X|X|AS: Half-width (arcsec)                    |n/a |Possible Bright |
 |       |                  | | |       >= maneuver uncertainty             |    |Star Hold       |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1274,12 +1274,7 @@ sub check_star_catalog {
 		   || $pixel_col > $col_max - $pix_slot_dither || $pixel_col < $col_min + $pix_slot_dither) {
     		push @warn,sprintf "$alarm [%2d] Angle Too Large.\n",$i;
 	    }
-	}	
-		
-        # Quandrant boundary interference ACA-013 ACA-014 (and ACA-012 if it were actually a check)
-	push @yellow_warn, sprintf "$alarm [%2d] Quadrant Boundary. \n",$i 
-	    unless ($type eq 'ACQ' or $type eq 'MON' or 
-		    (abs($yag-$y0) > $qb_dist + $slot_dither and abs($zag-$z0) > $qb_dist + $slot_dither ));
+	}
 
 	# Faint and bright limits ~ACA-009 ACA-010
 	if ($mag ne '---') {


### PR DESCRIPTION
Remove quadrant boundary checks (fid and guide star) in the Obsid code.  