### PR TITLE
Add a space before block of all warnings (change adds orange type)

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2016,7 +2016,7 @@ sub print_report {
 
     $o .= $table;
     
-    $o .= "\n" if (@{$self->{warn}} || @{$self->{yellow_warn}} || @{$self->{fyi}} );
+    $o .= "\n" if (@{$self->{warn}} || @{$self->{yellow_warn}} || @{$self->{fyi}} || @{$self->{orange_warn}});
 
 
 


### PR DESCRIPTION
Add a space before block of all warnings (change adds orange type).

Without the change, if there is just an orange warning, the space is missing after the catalog and before the warning.

Closes #241 