### PR TITLE
Use chandra_aca guide_count for t_ccd scaled counts

### DIFF
--- a/starcheck/data/characteristics.yaml
+++ b/starcheck/data/characteristics.yaml
@@ -60,8 +60,8 @@ no_starcat_oflsid:
    - RDE
    - DC_T
 
-ccd_temp_yellow_limit: -11.9
-ccd_temp_red_limit: -10.9
+ccd_temp_yellow_limit: -11.2
+ccd_temp_red_limit: -10.2
 
 n100_warm_frac_default: .15
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -22,10 +22,14 @@ use strict;
 use warnings;
 
 use Inline Python => q{
-
+import numpy as np
+from chandra_aca.star_probs import guide_count
 import Quaternion
 from Ska.quatutil import radec2yagzag
 import agasc
+
+def _guide_count(mags, t_ccd):
+    return float(guide_count(np.array(mags), t_ccd))
 
 
 def _get_agasc_stars(ra, dec, roll, radius, date, agasc_file):
@@ -2571,22 +2575,16 @@ sub count_guide_stars{
 ###################################################################################
     my $self=shift;
     my $c;
-    my $gui_count = 0.0;
 
     return 0.0 unless ($c = find_command($self, 'MP_STARCAT'));
+    my @mags = ();
     for my $i (1 .. 16){
 	if ($c->{"TYPE$i"} =~ /GUI|BOT/){
             my $mag = $c->{"GS_MAG$i"};
-            # Compute fractional guide star count using magnitude bins and fractions
-            # defined in ORViewer. (Note tab-ternary is if/elsif/else)
-            my $star_contrib = $mag <= 10.0  ? 1.0
-                             : $mag <= 10.2  ? 0.75
-                             : $mag <= 10.3  ? 0.5
-                             :                 0.0;
-            $gui_count += $star_contrib;
+            push @mags, $mag;
 	}
     }
-    return $gui_count;
+    return _guide_count(\@mags, $self->{ccd_temp});
 }
 
 ###################################################################################


### PR DESCRIPTION
Use chandra_aca guide_count for t_ccd scaled counts

(also updates planning limit so the defaults are more correct).