### PR TITLE
Safe mode 2018283 prov

### DIFF
--- a/ska_bin_starcheck
+++ b/ska_bin_starcheck
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 
 SKA_bin=`dirname $0`
 eval `${SKA_bin}/flt_envs -shell sh`

--- a/starcheck/data/aca_spec.json
+++ b/starcheck/data/aca_spec.json
@@ -404,7 +404,7 @@
             "max": 2.0, 
             "min": -1.0, 
             "name": "bias", 
-            "val": 0.067
+            "val": 0.055
         }, 
         {
             "comp_name": "coupling__aacccdpt__aca0", 

--- a/starcheck/data/aca_spec.json
+++ b/starcheck/data/aca_spec.json
@@ -404,7 +404,7 @@
             "max": 2.0, 
             "min": -1.0, 
             "name": "bias", 
-            "val": 0.0
+            "val": 0.067
         }, 
         {
             "comp_name": "coupling__aacccdpt__aca0", 

--- a/starcheck/src/lib/Ska/Starcheck/FigureOfMerit.pm
+++ b/starcheck/src/lib/Ska/Starcheck/FigureOfMerit.pm
@@ -37,7 +37,6 @@ def _prob_n_acq(acq_probs):
     return n_acq_probs.tolist(), n_or_fewer_probs.tolist()
 };
 
-our $CUM_PROB_LIMIT = 8e-3;
 
 sub make_figure_of_merit{
     my $c;
@@ -49,6 +48,8 @@ sub make_figure_of_merit{
     my %slot_probs;
 
     my $t_ccd = $self->{ccd_temp};
+    my $prob_limit = $t_ccd > -10.2 ? 1e-5 : 1e-3;
+
     my $date = $c->{date};
 
     foreach my $i (1..16) {
@@ -71,10 +72,12 @@ sub make_figure_of_merit{
 
     $self->{figure_of_merit} = {expected => substr(sum(@probs), 0, 4),
                                 cum_prob => [map { log($_) / log(10.0) } @{$n_or_fewer_probs}],
-                                cum_prob_bad => ($n_or_fewer_probs->[2] > $CUM_PROB_LIMIT)
+                                cum_prob_bad => ($n_or_fewer_probs->[2] > $prob_limit)
                                 };
-    if ($n_or_fewer_probs->[2] > $CUM_PROB_LIMIT){
-        push @{$self->{warn}}, ">> WARNING: Probability of 2 or fewer stars > $CUM_PROB_LIMIT\n";
+
+
+    if ($n_or_fewer_probs->[2] > $prob_limit){
+        push @{$self->{warn}}, ">> WARNING: Probability of 2 or fewer stars > $prob_limit\n";
     }
 
 }

--- a/starcheck/src/run_regress
+++ b/starcheck/src/run_regress
@@ -4,16 +4,14 @@
 
 RunRegression()
 # Run regression tests.
-# Arg 1 is the AGASC version (e.g. 1p5)
-# Arg 2 is the AGASC file for h5
-# Arg 3 is the fid characteristics name (e.g. fid_CHARACTERIS_FEB07)
+# Arg 1 is the AGASC file for h5
+# Arg 2 is the fid characteristics name (e.g. fid_CHARACTERIS_FEB07)
 {
   echo ""
   echo "***** Running starcheck on load $load *****"
 
-  agasc=${1}
-  agasc_file=${2}
-  fid_char=${3}
+  agasc_file=${1}
+  fid_char=${2}
 
   test=$regtestdir/$load
   release=$home/test_regress/release/$load
@@ -56,9 +54,9 @@ RunRegression()
       echo "cd $release"
       cd $release
       
-      echo "Running: $RELEASE/bin/starcheck -vehicle -agasc $agasc -fid_char $fid_char -dir $mphome/$load"
+      echo "Running: $RELEASE/bin/starcheck -vehicle -agasc_file $agasc_file -fid_char $fid_char -dir $mphome/$load"
       echo "**** (RELEASE VEHICLE) $load ****" >> $vlog
-      env SKA=$RELEASE PERL5LIB='' SYBASE='' SYBASE_OCS='' $RELEASE/bin/starcheck -vehicle -agasc $agasc -fid_char $fid_char -dir $mphome/$load 2>&1| tee -a $vlog
+      env SKA=$RELEASE PERL5LIB='' SYBASE='' SYBASE_OCS='' $RELEASE/bin/starcheck -vehicle -agasc_file $agasc_file -fid_char $fid_char -dir $mphome/$load 2>&1| tee -a $vlog
       perl -n -i.bak -e 'print if $. > 3' $release/v_starcheck.txt
     fi  
 
@@ -93,9 +91,9 @@ RunRegression()
     echo "cd $release"
     cd $release
 
-    echo "Running: $RELEASE/bin/starcheck -agasc $agasc -fid_char $fid_char -dir $mphome/$load"
+    echo "Running: $RELEASE/bin/starcheck -agasc_file $agasc_file -fid_char $fid_char -dir $mphome/$load"
     echo "**** (RELEASE) $load ****" >> $log
-    env SKA=$RELEASE PERL5LIB='' SYBASE='' SYBASE_OCS='' $RELEASE/bin/starcheck -agasc $agasc -fid_char $fid_char -dir $mphome/$load 2>&1| tee -a $log
+    env SKA=$RELEASE PERL5LIB='' SYBASE='' SYBASE_OCS='' $RELEASE/bin/starcheck -agasc_file $agasc_file -fid_char $fid_char -dir $mphome/$load 2>&1| tee -a $log
     perl -n -i.bak -e 'print if $. > 3' $release/starcheck.txt
   fi  
 
@@ -186,7 +184,7 @@ for load in \
     2006/MAR0606/oflsc \
     2006/NOV2006/oflsb
 do
-  RunRegression 1p6 /proj/sot/ska/data/agasc/agasc1p6.h5 fid_CHARACTERIS_JUL01
+  RunRegression /proj/sot/ska/data/agasc/agasc1p6.h5 fid_CHARACTERIS_JUL01
 done
 
 # Then, a bunch of agasc 1.6 loads with the updated fid characteristics
@@ -229,7 +227,7 @@ for load in \
     2015/DEC1115/oflsa \
     2015/DEC1115/oflsb
 do
-  RunRegression 1p6 /proj/sot/ska/data/agasc/agasc1p6.h5 fid_CHARACTERIS_FEB07
+  RunRegression /proj/sot/ska/data/agasc/agasc1p6.h5 fid_CHARACTERIS_FEB07
 done
 
 # Copy log and diffs to version directory

--- a/starcheck/version.py
+++ b/starcheck/version.py
@@ -15,7 +15,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '11.27'
+version = '11.28'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])


### PR DESCRIPTION
This implements several changes in starcheck to support load review after the 2018283 safe mode:

  - Sets the "fractional" guide count metric to use temperature-scaled magnitude limits for the counting
  - Sets the acquisition probability threshold to more conservative values per Tom's suggested thresholds in memo "ACA planning requirements for loads going forward"
  - Uses the ACA model from 24-Oct-2018 in chandra_models 3.18.1