### PR TITLE
Updates to accompany grid-acq-prob promotion

### DIFF
--- a/starcheck/data/characteristics.yaml
+++ b/starcheck/data/characteristics.yaml
@@ -60,8 +60,8 @@ no_starcat_oflsid:
    - RDE
    - DC_T
 
-ccd_temp_yellow_limit: -11.5
-ccd_temp_red_limit: -10.2
+ccd_temp_yellow_limit: -10.2
+ccd_temp_red_limit: -9.5
 
 n100_warm_frac_default: .15
 

--- a/starcheck/src/lib/Ska/Starcheck/FigureOfMerit.pm
+++ b/starcheck/src/lib/Ska/Starcheck/FigureOfMerit.pm
@@ -51,7 +51,7 @@ sub make_figure_of_merit{
     my %slot_probs;
 
     my $t_ccd = $self->{ccd_temp};
-    my $prob_limit = $t_ccd > -10.2 ? 1e-5 : 1e-3;
+    my $prob_limit = 0.008;
 
     my $date = $c->{date};
 

--- a/starcheck/version.py
+++ b/starcheck/version.py
@@ -15,7 +15,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '12.0'
+version = '12.1'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])


### PR DESCRIPTION
Updates to accompany the acquisition probability model in chandra_aca 4.24

   - Reverts provisional acquisition probability thresholds (sets back to P2=~2.1)
   - References the -9.5C planning limit
