### PR TITLE
Clip t_ccd and halfwidth 

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/FigureOfMerit.pm
+++ b/starcheck/src/lib/Ska/Starcheck/FigureOfMerit.pm
@@ -62,6 +62,15 @@ sub make_figure_of_merit{
             my $spoiler = grep(/Search spoiler/i, @warnings) ? 1 : 0;
             my $color = $c->{"GS_BV$i"};
             my $hw = $c->{"HALFW$i"};
+            if (($hw > 180) or ($hw < 60)){
+                push @{$self->{yellow_warn}}, sprintf(
+                    ">> WARNING: [%2d] Halfwidth %d outside range 60 to 180. Clipped in model.",
+                    $i, $hw);
+                # Clip hw if outside the range 60 to 180 for probabilities
+                $hw =   $hw < 60  ? 60
+                      : $hw > 180 ? 180
+                      : $hw ;
+            }
             my $star_prob = _acq_success_prob($date, $t_ccd, $mag, $color, $spoiler, $hw);
 	    push @probs, $star_prob;
             $slot_probs{$c->{"IMNUM$i"}} = $star_prob;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2616,4 +2616,12 @@ sub set_ccd_temps{
         push @{$self->{fyi}}, sprintf("$info CCD temperature exceeds %.1f C\n",
                                        $config{ccd_temp_red_limit});
     }
+    if (($self->{ccd_temp} > -1.0) or ($self->{ccd_temp} < -16.0)){
+        push @{$self->{yellow_warn}}, sprintf(
+            ">> WARNING: t_ccd %.2f outside range -16.0 to -1.0. Clipped.",
+            $self->{ccd_temp});
+        $self->{ccd_temp} = $self->{ccd_temp}  >  -1.0  ? -1.0
+                          : $self->{ccd_temp} < -16.0  ? -16.0
+                          : $self->{ccd_temp};
+    }
 }


### PR DESCRIPTION
Set to clip t_ccd and halfwidth (and add yellow warnings) instead of passing those out-of-range values to star_probs.  This prevents the UserWarnings at console.

