### PR TITLE
More small dither-related changes

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1933,7 +1933,9 @@ sub print_report {
     if ( ( defined $self->{ra} ) and (defined $self->{dec}) and (defined $self->{roll})){
 	$o .= sprintf "RA, Dec, Roll (deg): %12.6f %12.6f %12.6f\n", $self->{ra}, $self->{dec}, $self->{roll};
     }
-    if (defined $self->{dither_guide}){
+    # This 'defined' check has been changed to be a test on the amplitude.  It looks like for the undefined
+    # case such as replan, this {dither_guide} is set but is an empty hash ref.
+    if (defined $self->{dither_guide}->{ampl_y}){
         my $z_amp = int($self->{dither_guide}->{ampl_p} + .5);
         my $y_amp = int($self->{dither_guide}->{ampl_y} + .5);
         if ($self->{dither_guide}->{state} eq 'ENAB'){

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -728,11 +728,10 @@ sub check_dither {
         if ((not standard_dither($guide_dither)) or not standard_dither($acq_dither)){
             push @{$self->{yellow_warn}}, "$alarm Non-standard dither\n";
         }
-        else{
-            if (($guide_dither->{ampl_p} != $acq_dither->{ampl_p})
-                    or ($guide_dither->{ampl_y} != $acq_dither->{ampl_y})){
-                push @{$self->{yellow_warn}}, "$alarm Dither changes between ACQ and GUI \n";
-            }
+        if (($guide_dither->{ampl_p} != $acq_dither->{ampl_p})
+                or ($guide_dither->{ampl_y} != $acq_dither->{ampl_y})){
+            push @{$self->{yellow_warn}}, sprintf("$alarm Reviewed with ACQ dither Y=%.1f Z=%.1f \n",
+                                                  $acq_dither->{ampl_y}, $acq_dither->{ampl_p});
         }
     }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -730,8 +730,8 @@ sub check_dither {
         }
         if (($guide_dither->{ampl_p} != $acq_dither->{ampl_p})
                 or ($guide_dither->{ampl_y} != $acq_dither->{ampl_y})){
-            push @{$self->{yellow_warn}}, sprintf("$alarm Reviewed with ACQ dither Y=%.1f Z=%.1f \n",
-                                                  $acq_dither->{ampl_y}, $acq_dither->{ampl_p});
+            push @{$self->{fyi}}, sprintf("$info Reviewed with ACQ dither Y=%.1f Z=%.1f \n",
+                                          $acq_dither->{ampl_y}, $acq_dither->{ampl_p});
         }
     }
 
@@ -771,9 +771,9 @@ sub check_dither {
 
     if (($self->{dither_guide}->{ampl_y_max} != $self->{dither_guide}->{ampl_y})
             or ($self->{dither_guide}->{ampl_p_max} != $self->{dither_guide}->{ampl_p})){
-        push @{$self->{yellow_warn}}, sprintf("$alarm Max Y Z ampl during guide used for checking Y=%.1f Z=%.1f \n",
-                                              $self->{dither_guide}->{ampl_y_max} + 0.0,
-                                              $self->{dither_guide}->{ampl_p_max} + 0.0);
+        push @{$self->{fyi}}, sprintf("$info Max Y Z ampl during guide used for checking Y=%.1f Z=%.1f \n",
+                                      $self->{dither_guide}->{ampl_y_max} + 0.0,
+                                      $self->{dither_guide}->{ampl_p_max} + 0.0);
     }
 
     # For eng obs, don't have OR to specify dither, so stop before doing vs-OR comparisons

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1172,27 +1172,6 @@ sub check_star_catalog {
     my $max_z = $z_ang_min;
     my $min_z = $z_ang_max;
 
-    my ($dither_acq_y, $dither_acq_z, $dither_guide_y, $dither_guide_z);
-    if (defined $self->{dither_acq}){
-	$dither_acq_y = $self->{dither_acq}->{ampl_y};
-        $dither_acq_z = $self->{dither_acq}->{ampl_p};
-    } else {
-        push @{$self->{yellow_warn}},
-            "$alarm Acquisition dither could not be determined, using 20\"x20\" for checking.\n";
-	$dither_acq_y = 20.0;
-	$dither_acq_z = 20.0;
-    }
-
-    if (defined $self->{dither_guide}->{ampl_y_max}){
-	$dither_guide_y = $self->{dither_guide}->{ampl_y_max};
-        $dither_guide_z = $self->{dither_guide}->{ampl_p_max};
-    } else {
-        push @{$self->{yellow_warn}},
-            "$alarm Guide dither could not be determined, using 20\"x20\" for checking.\n";
-	$dither_guide_y = 20.0;
-	$dither_guide_z = 20.0;
-    }
-
 
     my @warn = ();
     my @orange_warn = ();
@@ -1229,6 +1208,29 @@ sub check_star_catalog {
 	push @{$self->{warn}}, "$alarm No star catalog for obsid $obsid ($oflsid). \n";		    
 	return;
     }
+
+    my ($dither_acq_y, $dither_acq_z, $dither_guide_y, $dither_guide_z);
+    if (defined $self->{dither_acq}){
+	$dither_acq_y = $self->{dither_acq}->{ampl_y};
+        $dither_acq_z = $self->{dither_acq}->{ampl_p};
+    } else {
+        push @{$self->{yellow_warn}},
+            "$alarm Acquisition dither could not be determined, using 20\"x20\" for checking.\n";
+	$dither_acq_y = 20.0;
+	$dither_acq_z = 20.0;
+    }
+
+    if (defined $self->{dither_guide}->{ampl_y_max}){
+	$dither_guide_y = $self->{dither_guide}->{ampl_y_max};
+        $dither_guide_z = $self->{dither_guide}->{ampl_p_max};
+    } else {
+        push @{$self->{yellow_warn}},
+            "$alarm Guide dither could not be determined, using 20\"x20\" for checking.\n";
+	$dither_guide_y = 20.0;
+	$dither_guide_z = 20.0;
+    }
+
+
     # Decrement minimum number of guide stars on ORs if a monitor window is commanded
     $min_guide -= @{$self->{mon}} if $is_science;
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1177,6 +1177,8 @@ sub check_star_catalog {
 	$dither_acq_y = $self->{dither_acq}->{ampl_y};
         $dither_acq_z = $self->{dither_acq}->{ampl_p};
     } else {
+        push @{$self->{yellow_warn}},
+            "$alarm Acquisition dither could not be determined, using 20\"x20\" for checking.\n";
 	$dither_acq_y = 20.0;
 	$dither_acq_z = 20.0;
     }
@@ -1185,6 +1187,8 @@ sub check_star_catalog {
 	$dither_guide_y = $self->{dither_guide}->{ampl_y_max};
         $dither_guide_z = $self->{dither_guide}->{ampl_p_max};
     } else {
+        push @{$self->{yellow_warn}},
+            "$alarm Guide dither could not be determined, using 20\"x20\" for checking.\n";
 	$dither_guide_y = 20.0;
 	$dither_guide_z = 20.0;
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -694,6 +694,11 @@ sub check_dither {
     my $obs_tstart = $self->{obs_tstart};
     my $obs_tstop = $self->{obs_tstop};
 
+    unless (defined $obs_tstart){
+        push @{$self->{warn}}, "$alarm Cannot determine obs start time for dither. \n";
+        return;
+    }
+
     # Determine guide dither by finding the last dither commanding before
     # the start of observation (+ 8 minutes)
     my $guide_dither;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -695,7 +695,7 @@ sub check_dither {
     my $obs_tstop = $self->{obs_tstop};
 
     unless (defined $obs_tstart){
-        push @{$self->{warn}}, "$alarm Cannot determine obs start time for dither. \n";
+        push @{$self->{warn}}, "$alarm Cannot determine obs start time for dither, not checking.\n";
         return;
     }
 


### PR DESCRIPTION
More small dither-related changes

This PR

1) puts the tiny bugfix to short-circuit dither checks sooner (when no observation start time available to do them). 
2) tracks the maximum guide amplitude in y and z over the observation instead of just the guide amplitudes 8 minutes after maneuver end (should only matter for big dither but...)
3) adds a green warning for observations that have different acq and guide dither (again should only be interesting for big dither)