### PR TITLE
Update edge checks

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -36,6 +36,15 @@ from proseco.core import ACABox
 from proseco.guide import get_imposter_mags
 
 def _yagzag_to_pixels(yag, zag):
+    """
+    Call chandra_aca.transform.yagzag_to_pixels.
+    This wrapper is set to pass allow_bad=True, as exceptions from the Python side
+    in this case would not be helpful, and the boundary checks and such will work fine
+    on the Perl side even if the returned row/col is off the CCD.
+    :params yag: y-angle arcsecs (hopefully as a number from the Perl)
+    :params zag: z-angle arcsecs (hopefully as a number from the Perl)
+    :returns tuple: row, col as floats
+    """
     row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
     return float(row), float(col)
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -36,8 +36,6 @@ from proseco.core import ACABox
 from proseco.guide import get_imposter_mags
 
 def _yagzag_to_pixels(yag, zag):
-    yag = float(yag)
-    zag = float(zag)
     row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
     return float(row), float(col)
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1489,8 +1489,8 @@ sub check_star_catalog {
 
             # Set "dither" for FID to be pseudodither of 5.0 to give 1 pix margin
             # Set "track phase" dither for BOT GUI to guide dither or 20.0 if undefined.
-            my $dither_track_y = ($type eq 'FID') ? 5.0 : $self->{dither_guide}->{ampl_y} or 20.0;
-            my $dither_track_p = ($type eq 'FID') ? 5.0 : $self->{dither_guide}->{ampl_p} or 20.0;
+            my $dither_track_y = ($type eq 'FID') ? 5.0 : $self->{dither_guide}->{ampl_y_max} or 20.0;
+            my $dither_track_p = ($type eq 'FID') ? 5.0 : $self->{dither_guide}->{ampl_p_max} or 20.0;
 
             my $pix_window_pad = 7; # half image size + point uncertainty + ? + 1 pixel of margin
             my $pix_row_pad = 8;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2704,10 +2704,7 @@ sub star_image_map {
 		my $sid = $cat_star->{id};
 		my $yag = $cat_star->{yag};
 		my $zag = $cat_star->{zag};
-		my ($pix_row, $pix_col) = ('None', 'None');
-		eval{
-			($pix_row, $pix_col) = toPixels($yag, $zag);		
-		};
+		my ($pix_row, $pix_col) = _yagzag_to_pixels($yag, $zag);
 		my $image_x = 54 + ((2900 - $yag) * $pix_scale);
 		my $image_y = 39 + ((2900 - $zag) * $pix_scale);
 		my $star = '<area href="javascript:void(0);"' . "\n"

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1519,14 +1519,17 @@ sub check_star_catalog {
                     }
                 }
             }
-
+            # For acq stars, the distance to the row/col padded limits are also confirmed,
+            # but code to track which boundary is exceeded (row or column) is not present.
+            # Note from above that the pix_row_pad used for row_lim has 7 more pixels of padding
+            # than the pix_col_pad used to determine row_lim.
             my $acq_edge_delta = min(($row_lim - $dither_acq_y / $ang_per_pix) - abs($pixel_row),
                                      ($col_lim - $dither_acq_p / $ang_per_pix) - abs($pixel_col));
-            if (($type eq 'ACQ') and ($acq_edge_delta < 0)){
-                push @yellow_warn,sprintf "$alarm [%2d] Off (padded) CCD.\n",$i;
+            if (($type =~ /BOT|ACQ/) and ($acq_edge_delta < (-1 * 12))){
+                push @orange_warn, sprintf "$alarm [%2d] Acq Off (padded) CCD by > 60 arcsec.\n",$i;
             }
-            elsif (($type eq 'ACQ') and ($acq_edge_delta < (-1 * 12))){
-                push @orange_warn,sprintf "$alarm [%2d] Off (padded) CCD by > 60 arcsec.\n",$i;
+            elsif (($type =~ /BOT|ACQ/) and ($acq_edge_delta < 0)){
+                push @{$self->{fyi}}, sprintf "$alarm [%2d] Acq Off (padded) CCD (P_ACQ should be < .5)\n",$i;
             }
         }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1485,12 +1485,12 @@ sub check_star_catalog {
 	else{
             # Set "acq phase" dither to acq dither or 20.0 if undefined
             my $dither_acq_y = $self->{dither_acq}->{ampl_y} or 20.0;
-            my $dither_acq_p = $self->{dither_acq}->{ampl_y} or 20.0;
+            my $dither_acq_p = $self->{dither_acq}->{ampl_p} or 20.0;
 
             # Set "dither" for FID to be pseudodither of 5.0 to give 1 pix margin
             # Set "track phase" dither for BOT GUI to guide dither or 20.0 if undefined.
             my $dither_track_y = ($type eq 'FID') ? 5.0 : $self->{dither_guide}->{ampl_y} or 20.0;
-            my $dither_track_p = ($type eq 'FID') ? 5.0 : $self->{dither_guide}->{ampl_y} or 20.0;
+            my $dither_track_p = ($type eq 'FID') ? 5.0 : $self->{dither_guide}->{ampl_p} or 20.0;
 
             my $pix_window_pad = 7; # half image size + point uncertainty + ? + 1 pixel of margin
             my $pix_row_pad = 8;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1355,10 +1355,10 @@ sub check_star_catalog {
     }
 
     # Seed smallest maximums and largest minimums for guide star box
-    my $max_y = 3000;
-    my $min_y = -3000;
-    my $max_z = 3000;
-    my $min_z = -3000;
+    my $max_y = -3000;
+    my $min_y = 3000;
+    my $max_z = -3000;
+    my $min_z = 3000;
 
     foreach my $i (1..16) {
 	(my $sid  = $c->{"GS_ID$i"}) =~ s/[\s\*]//g;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1507,19 +1507,19 @@ sub check_star_catalog {
                               'col' => ($pixel_col < 0) ? -1 : 1);
 
             if ($type =~ /BOT|GUI|FID/){
-                foreach my $lim ('row', 'col'){
-                    my $track_delta = abs($track_limits{$lim}) - abs($pixel{$lim});
+                foreach my $axis ('row', 'col'){
+                    my $track_delta = abs($track_limits{$axis}) - abs($pixel{$axis});
                     if ($track_delta < 0){
-                        push @warn, sprintf "$alarm [%2d] Off (padded) CCD $lim lim %.1f val %.1f delta %.1f\n",
-                            $i, $pixel_sign{$lim} * $track_limits{$lim}, $track_delta;
+                        push @warn, sprintf "$alarm [%2d] Off (padded) CCD $axis lim %.1f val %.1f delta %.1f\n",
+                            $i, $pixel_sign{$axis} * $track_limits{$axis}, $track_delta;
                     }
                     elsif ($track_delta < 3){
-                        push @orange_warn, sprintf "$alarm [%2d] Within 3 pix of CCD $lim lim %.1f val %.1f delta %.1f\n",
-                            $i, $pixel_sign{$lim} * $track_limits{$lim}, $pixel{$lim}, $track_delta;
+                        push @orange_warn, sprintf "$alarm [%2d] Within 3 pix of CCD $axis lim %.1f val %.1f delta %.1f\n",
+                            $i, $pixel_sign{$axis} * $track_limits{$axis}, $pixel{$axis}, $track_delta;
                     }
                     elsif ($track_delta < 6){
-                        push @yellow_warn, sprintf "$alarm [%2d] Within 6 pix of CCD $lim lim %.1f val %.1f delta %.1f\n",
-                            $i, $pixel_sign{$lim} * $track_limits{$lim}, $pixel{$lim}, $track_delta;
+                        push @yellow_warn, sprintf "$alarm [%2d] Within 6 pix of CCD $axis lim %.1f val %.1f delta %.1f\n",
+                            $i, $pixel_sign{$axis} * $track_limits{$axis}, $pixel{$axis}, $track_delta;
                     }
                 }
             }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1509,12 +1509,8 @@ sub check_star_catalog {
             if ($type =~ /BOT|GUI|FID/){
                 foreach my $axis ('row', 'col'){
                     my $track_delta = abs($track_limits{$axis}) - abs($pixel{$axis});
-                    if ($track_delta < 0){
-                        push @warn, sprintf "$alarm [%2d] Off (padded) CCD $axis lim %.1f val %.1f delta %.1f\n",
-                            $i, $pixel_sign{$axis} * $track_limits{$axis}, $track_delta;
-                    }
-                    elsif ($track_delta < 3){
-                        push @orange_warn, sprintf "$alarm [%2d] Within 3 pix of CCD $axis lim %.1f val %.1f delta %.1f\n",
+                    if ($track_delta < 3){
+                        push @warn, sprintf "$alarm [%2d] Less than 3 pix edge margin $axis lim %.1f val %.1f delta %.1f\n",
                             $i, $pixel_sign{$axis} * $track_limits{$axis}, $pixel{$axis}, $track_delta;
                     }
                     elsif ($track_delta < 6){

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1500,12 +1500,12 @@ sub check_star_catalog {
         if ($type =~ /BOT|GUI|FID/){
             foreach my $axis ('row', 'col'){
                 my $track_delta = abs($track_limits{$axis}) - abs($pixel{$axis});
-                if ($track_delta < 3){
-                    push @warn, sprintf "$alarm [%2d] Less than 3 pix edge margin $axis lim %.1f val %.1f delta %.1f\n",
+                if ($track_delta < 2.5){
+                    push @warn, sprintf "$alarm [%2d] Less than 2.5 pix edge margin $axis lim %.1f val %.1f delta %.1f\n",
                         $i, $pixel_sign{$axis} * $track_limits{$axis}, $pixel{$axis}, $track_delta;
                 }
-                elsif ($track_delta < 6){
-                    push @yellow_warn, sprintf "$alarm [%2d] Within 6 pix of CCD $axis lim %.1f val %.1f delta %.1f\n",
+                elsif ($track_delta < 5){
+                    push @orange_warn, sprintf "$alarm [%2d] Within 5 pix of CCD $axis lim %.1f val %.1f delta %.1f\n",
                         $i, $pixel_sign{$axis} * $track_limits{$axis}, $pixel{$axis}, $track_delta;
                 }
             }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1522,7 +1522,7 @@ sub check_star_catalog {
         # For acq stars, the distance to the row/col padded limits are also confirmed,
         # but code to track which boundary is exceeded (row or column) is not present.
         # Note from above that the pix_row_pad used for row_lim has 7 more pixels of padding
-        # than the pix_col_pad used to determine row_lim.
+        # than the pix_col_pad used to determine col_lim.
         my $acq_edge_delta = min(($row_lim - $dither_acq_y / $ang_per_pix) - abs($pixel_row),
                                  ($col_lim - $dither_acq_p / $ang_per_pix) - abs($pixel_col));
         if (($type =~ /BOT|ACQ/) and ($acq_edge_delta < (-1 * 12))){


### PR DESCRIPTION
This fixes the half-pixel offset in the CCD edges (-512.5 -> -512.0 etc),
adds new warns if an ACQ star is more than an arcmin off the CCD, and adds
new warnings for guide stars that are close to the (dither, window,
and row/col pad padded) edge.