### PR TITLE
Add 350392600 (too bright 3.6 mag) to manual bad star list

### DIFF
--- a/starcheck/data/manual_bad_stars
+++ b/starcheck/data/manual_bad_stars
@@ -1,3 +1,4 @@
+350392600 Too bright, 3.6 mag in obsid 21252, catalog mag 7.6 (TA/JMC 17-Jan-2019)
 797847184 not found as GS in 49383 or 49382, exclude per Tom 12-Mar-2018
 914493824 Too bright, exclude per Eric 15-Aug-2016
 509225640 Too bright, 5.1 mag, exclude per Eric (JMC 17-Feb-2015)


### PR DESCRIPTION
Closes #279 
