### PR TITLE
Add manual bad star 1158290496 (bad position / PM)

### DIFF
--- a/starcheck/data/agasc.bad
+++ b/starcheck/data/agasc.bad
@@ -1,3 +1,5 @@
+1158290496 Incorrect position or proper motion (obsid 19763) (TA 18-Jan-2019)
+350392600 Too bright, 3.6 mag in obsid 21252, catalog mag 7.6 (TA/JMC 17-Jan-2019)
 797847184 not found as GS in 49383 or 49382, exclude per Tom 12-Mar-2018
 914493824 Too bright, exclude per Eric 15-Aug-2016
 509225640 Too bright, 5.1 mag, exclude per Eric (JMC 17-Feb-2015)

--- a/starcheck/data/manual_bad_stars
+++ b/starcheck/data/manual_bad_stars
@@ -1,3 +1,4 @@
+1158290496 Incorrect position or proper motion (obsid 19763) (TA 18-Jan-2019)
 350392600 Too bright, 3.6 mag in obsid 21252, catalog mag 7.6 (TA/JMC 17-Jan-2019)
 797847184 not found as GS in 49383 or 49382, exclude per Tom 12-Mar-2018
 914493824 Too bright, exclude per Eric 15-Aug-2016


### PR DESCRIPTION
In obsid 19763 this was seen with a centroid offset of around 5 arcsec, generating a worst-case situation where it is persistently just inside the Kalman limit threshold (5 arcsec box).  It may be that the PM is wrong (doesn't exist) or the position is wrong, but in any case we should not use this star.

I think we can merge this with only a "smoke" test without re-doing the entire regression suite.