### PR TITLE
Use get_effective_t_ccd

### DIFF
--- a/starcheck/data/characteristics.yaml
+++ b/starcheck/data/characteristics.yaml
@@ -62,8 +62,8 @@ no_starcat_oflsid:
    - RDE
    - DC_T
 
-ccd_temp_yellow_limit: -10.2
-ccd_temp_red_limit: -9.5
+ccd_temp_yellow_limit: -9.5
+ccd_temp_red_limit: -8.5
 
-n100_warm_frac_default: .15
+n100_warm_frac_default: .20
 


### PR DESCRIPTION
Use get_effective_t_ccd

Starcheck needs the effective_t_ccd a bunch of places anyway, so I'm not sure if we win anything by doing the get_aca_catalog transition.  I'll work that in another branch.

Of course, if I'm calling get_effective_t_ccd, the trick is to confirm I'm not accidentally calling it twice on any input temperature.
