### PR TITLE
Make the sandbox launcher work on standalone Ska3

### DIFF
--- a/sandbox_starcheck
+++ b/sandbox_starcheck
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 DIR=`dirname $0`
-export PYTHONHOME=$SKA
+PYTHON_EXE=`which python`
+PYTHON_DIR=`dirname $PYTHON_EXE`
+export PYTHONHOME=`dirname $PYTHON_DIR`
 export PYTHONPATH=$DIR:$PYTHONPATH
 PERL_INLINE_DIRECTORY=`mktemp -d -t starcheck_inline.XXXXXX` || exit 1
 export PERL_INLINE_DIRECTORY


### PR DESCRIPTION
This seems like a safe change in that it doesn't impact production starcheck.
