### PR TITLE
Add a run_start_time and change initial state determination per #319

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -113,6 +113,10 @@ def get_ccd_temps(oflsdir, outdir='out',
     :param json_obsids: file-like object or string containing JSON of
                         starcheck Obsid objects
     :param model_spec: xija ACA model specification
+    :param run_start_time: Chandra.Time date used as a reference time to determine initial
+                     seed state with temperature telemetry.  The initial seed state will
+                     be at the end of available telemetry that is also before run_start_time,
+                     before the beginning of backstop cmds, and before "now".
     :param verbose: Verbosity (0=quiet, 1=normal, 2=debug)
     :returns: JSON dictionary of labeled dwell intervals with max temperatures
     """

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -124,14 +124,14 @@ def get_ccd_temps(oflsdir, outdir='out',
 
     # Store info relevant to processing for use in outputs
     proc = {'run_user': os.environ['USER'],
-            'actual_run_time': time.ctime(),
+            'execution_time': time.ctime(),
             'run_start_time': run_start_time,
             'errors': []}
     logger.info('##############################'
                 '#######################################')
     logger.info('# %s run at %s by %s'
-                % (TASK_NAME, proc['actual_run_time'], proc['run_user']))
-    logger.info("# Using {} as run_start_time".format(run_start_time.date))
+                % (TASK_NAME, proc['execution_time'], proc['run_user']))
+    logger.info("# Continuity run_start_time = {}".format(run_start_time.date))
     logger.info('# {} version = {}'.format(TASK_NAME, VERSION))
     logger.info('###############################'
                 '######################################\n')

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -145,8 +145,6 @@ def run_start_time(run_start, backstop_start):
             ref_time = DateTime(backstop_datetime + run_start)
     except:
         pass
-    print(ref_time.date)
-    print(backstop_datetime.date)
     return ref_time.date
 
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -116,7 +116,7 @@ def get_now_time():
 
 
 def date_for_printing(date):
-    date = date.decode('ascii')
+    date = de_bytestr(date)
     dt = datetime.datetime.fromtimestamp(DateTime(date).unix)
     dt = dt.astimezone(tz.tzlocal())
     return dt.strftime("%a %b %d %H:%M:%S %Z %Y");

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -115,12 +115,6 @@ def get_now_time():
     return DateTime().date
 
 
-def date_for_printing(date):
-    date = de_bytestr(date)
-    dt = datetime.datetime.fromtimestamp(DateTime(date).unix)
-    dt = dt.astimezone(tz.tzlocal())
-    return dt.strftime("%a %b %d %H:%M:%S %Z %Y");
-
 };
 
 
@@ -674,7 +668,8 @@ close($JSON_OUT);
 my %save_hash;
 
 my $out = '<TABLE><TD><PRE> ';
-my $date = date_for_printing($RUN_START_TIME);
+my $date = `date`;
+chomp $date;
 
 my $hostname = hostname;
 $save_hash{run}{date} = $date;

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -48,9 +48,7 @@ $SIG{ __DIE__ } = sub { Carp::confess( @_ )};
 use Inline Python => q{
 
 import os
-import datetime
 import traceback
-from dateutil import tz
 
 from Chandra.Time import DateTime
 from chandra_aca.star_probs import set_acq_model_ms_filter

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -137,7 +137,7 @@ def get_run_start_time(run_start_time, backstop_start):
     # time to be a time run_start_time days back from backstop start
     try:
         run_start_time = float(run_start_time)
-    except TypeError:
+    except ValueError:
         ref_time = DateTime(run_start_time)
     else:
         if run_start_time < 0:


### PR DESCRIPTION
Add a run_start_time for regression and change the determination of
the reference / initial / seed state with temperature.  The previous
code used a state at least 3 days before backstop tstart and at least
one our before the last available telemetry.  The new code uses a state
within 1400 seconds of the end of available telemetry (where the
available telemetry is limited by either real availability, backstop
tstart, or the new 'run_start_time' option).