### PR TITLE
Add checks for skare3 perl and deps in launchers

### DIFF
--- a/sandbox_starcheck
+++ b/sandbox_starcheck
@@ -1,10 +1,28 @@
 #!/bin/bash
 
 DIR=`dirname $0`
+export PYTHONPATH=$DIR:$PYTHONPATH
+
 PYTHON_EXE=`which python`
 PYTHON_DIR=`dirname $PYTHON_EXE`
 export PYTHONHOME=`dirname $PYTHON_DIR`
-export PYTHONPATH=$DIR:$PYTHONPATH
+
+# Check for skare3 perl
+if [[ ! -f ${PYTHONHOME}/bin/perl ]];
+then
+    echo "skare3 perl not installed. conda install perl perl-core-deps perl-ska-classic"
+    exit 1
+fi
+# Check for perl deps
+perl -e "use IO::All; use Time::DayOfYear;"
+if [[ $? -ne 0 ]];
+then
+    echo "****"
+    echo "Missing starcheck ska3 perl dependencies.  Please 'conda install perl perl-core-deps perl-ska-classic'"
+    echo "****"
+    exit 1
+fi
+
 PERL_INLINE_DIRECTORY=`mktemp -d -t starcheck_inline.XXXXXX` || exit 1
 export PERL_INLINE_DIRECTORY
 perl -I ${DIR}/starcheck/src/lib ${DIR}/starcheck/src/starcheck.pl "$@"

--- a/starcheck/src/starcheck
+++ b/starcheck/src/starcheck
@@ -9,6 +9,23 @@
 # for flight starcheck
 unset PYTHONPATH
 export PYTHONHOME=$SKA
+
+# Check for skare3 perl
+if [[ ! -f ${PYTHONHOME}/bin/perl ]];
+then
+    echo "skare3 perl not installed. conda install perl perl-core-deps perl-ska-classic"
+    exit 1
+fi
+# Check for perl deps
+perl -e "use IO::All; use Time::DayOfYear;"
+if [[ $? -ne 0 ]];
+then
+    echo "****"
+    echo "Missing starcheck ska3 perl dependencies.  Please 'conda install perl perl-core-deps perl-ska-classic'"
+    echo "****"
+    exit 1
+fi
+
 PERL_INLINE_DIRECTORY=`mktemp -d -t starcheck_inline.XXXXXX` || exit 1
 export PERL_INLINE_DIRECTORY
 STARCHECK=`python -c 'import starcheck; print(starcheck.__path__[0])'`


### PR DESCRIPTION
Add checks for skare3 perl and deps in launchers

This will print more useful output if the conda environment doesn't have the necessary Perl pieces to run starcheck for load review.

There's still duplication between `sandbox_starcheck` and `starcheck` but overall I think this is still benign.