### PR TITLE
Update ccd red/yellow limits for Apr2020 increase

### DIFF
--- a/starcheck/data/characteristics.yaml
+++ b/starcheck/data/characteristics.yaml
@@ -9,8 +9,8 @@ no_starcat_oflsid:
    - RDE
    - DC_T
 
-ccd_temp_yellow_limit: -8.8
-ccd_temp_red_limit: -7.8
+ccd_temp_yellow_limit: -8.1
+ccd_temp_red_limit: -7.1
 
 n100_warm_frac_default: .20
 


### PR DESCRIPTION
## Description

Update ccd red/yellow limits for Apr2020 increase.
This characteristics item is also used to decide to report when effective temperature is greater than supplied.

## Testing

- [x] Functional testing (Ran on APR2720A and see expected INFO changes and red and green line changes in CCD temperature plot)

Fixes #