### PR TITLE
Check for perl based on location of Ska Python

### DIFF
--- a/starcheck/src/starcheck
+++ b/starcheck/src/starcheck
@@ -8,12 +8,15 @@
 # Unset PYTHONPATH because custom PYTHONPATH should never be allowed
 # for flight starcheck
 unset PYTHONPATH
-export PYTHONHOME=$SKA
+
+PYTHON_EXE=`which python`
+PYTHON_DIR=`dirname $PYTHON_EXE`
+export PYTHONHOME=`dirname $PYTHON_DIR`
 
 # Check for skare3 perl
 if [[ ! -f ${PYTHONHOME}/bin/perl ]];
 then
-    echo "skare3 perl not installed. conda install perl perl-core-deps perl-ska-classic"
+    echo "skare3 perl not installed. conda install perl perl-ska-convert"
     exit 1
 fi
 # Check for perl deps


### PR DESCRIPTION
## Description

This is basically what is used for the sandbox starcheck, and it appears to work fine.

## Testing

- [N/A] Passes unit tests
- [x] Functional testing (partial)

### Minimal testing

I installed this into a ska3-shiny environment on Mac and confirmed that it ran without error on a representative recent set of load products.