### PR TITLE
Handle lack of Notes on MON star in guide summary

### DIFF
--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -569,7 +569,12 @@ sub guide{
 	    }
 	    if ($line =~ /^MON/){
 		my @l= split ' ', $line;
-		push @{$guidesumm{$oflsid}{info}}, "MON --- $l[2] $l[3] --- $l[5] $l[6] $l[7]";
+		if (scalar(@l) == 8){
+		    push @{$guidesumm{$oflsid}{info}}, "MON --- $l[2] $l[3] --- $l[5] $l[6] $l[7]";
+		}
+		else{
+		    push @{$guidesumm{$oflsid}{info}}, "MON --- $l[2] $l[3] --- $l[5] $l[6]";
+		}
 	    }
 	}
     }


### PR DESCRIPTION
## Description

Little fix to stop Uninitialized Perl warnings on MON windows in guide summary without Notes

## Testing

- [x] There are no unit tests
- [x] the fix worked to stop the uninitialized warns for SEP2120A without introducing any other errors

Fixes #353 