### PR TITLE
change yaml loading to avoid warning

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -153,7 +153,7 @@ def get_ccd_temps(oflsdir, outdir='out',
                 '######################################\n')
 
     # load more general starcheck characteristics to get red/yellow limits
-    char = yaml.load(open(char_file))
+    char = yaml.load(open(char_file), Loader=yaml.FullLoader)
 
     # save spec file in out directory
     shutil.copy(model_spec, outdir)

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -153,7 +153,7 @@ def get_ccd_temps(oflsdir, outdir='out',
                 '######################################\n')
 
     # load more general starcheck characteristics to get red/yellow limits
-    char = yaml.load(open(char_file), Loader=yaml.FullLoader)
+    char = yaml.load(open(char_file), Loader=yaml.SafeLoader)
 
     # save spec file in out directory
     shutil.copy(model_spec, outdir)


### PR DESCRIPTION
## Description

This just changes theloading statement according to https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

It should fix the test failure in post_check_logs.py

## Testing

- [ ] ~Passes unit tests on MacOS, linux, Windows (at least one required)~ (this has no unit tests)
- [x] Functional testing 

Fixes #