### PR TITLE
Fix info statement regarding being off padded CCD

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1591,7 +1591,7 @@ sub check_star_catalog {
             push @orange_warn, sprintf "[%2d] Acq Off (padded) CCD by > 60 arcsec.\n",$i;
         }
         elsif (($type =~ /BOT|ACQ/) and ($acq_edge_delta < 0)){
-            push @{$self->{fyi}}, sprintf "[%2d] Acq Off (padded) CCD (P_ACQ should be < .5)\n",$i;
+            push @{$self->{fyi}}, sprintf "[%2d] Acq Off (padded) CCD\n",$i;
         }
 
 	# Faint and bright limits ~ACA-009 ACA-010


### PR DESCRIPTION
## Description

The statement that P_ACQ should be less than 0.5 was misleading.

## Testing

No testing done since this is just changing the text of a message.

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [N/A] Functional testing
