### PR TITLE
Remove all make_stars stuff

### DIFF
--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -109,10 +109,6 @@ Observing
 
       - CRddd_hhvv.tlr.html
  
-      - make_stars.txt
- 
-      - make_stars.txt.html
- 
       - mdddd:hhvv.dot.html
  
       - mgddd:hhvv.sum.html
@@ -137,10 +133,6 @@ Vehicle
       - VRddd:hhvv.backstop.html
 
       - VRddd_hhvv.tlr.html
- 
-      - make_stars.txt
- 
-      - make_stars.txt.html
  
       - mdddd:hhvv.dot.html
  

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2155,7 +2155,6 @@ sub print_report {
 	if ($self->{or_file});
     $o .= sprintf("<A HREF=\"%s/%s.html#%s\">MANVR</A> ", $self->{STARCHECK}, basename($self->{mm_file}), $self->{dot_obsid});
     $o .= sprintf("<A HREF=\"%s/%s.html#%s\">DOT</A> ", $self->{STARCHECK}, basename($self->{dot_file}), $self->{obsid});
-    $o .= sprintf("<A HREF=\"%s/%s.html#%s\">MAKE_STARS</A> ", $self->{STARCHECK}, "make_stars.txt" , $self->{obsid});
     $o .= sprintf("<A HREF=\"%s/%s.html#%s\">TLR</A> ", $self->{STARCHECK}, basename($self->{tlr_file}) , $self->{obsid});
     $o .= sprintf "\n\n";
     for my $n (1 .. 10) {		# Allow for multiple TARGQUAT cmds, though 2 is the typical limit

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -801,22 +801,6 @@ $out .= '</PRE></TD></TABLE> ';
 
 my $ptf = PoorTextFormat->new();
 
-# Write make_stars file
-my $make_stars = "$STARCHECK/make_stars.txt";
-open (my $OUT, "> $make_stars") or die "Couldn't open $make_stars for writing\n";
-foreach my $obsid (@obsid_id) {
-    my $c = $obs{$obsid};
-    my $format = ($c->{obsid} =~ /^[0-9]+$/) ? "%05d" : "%s";
-    if ( (defined $c->{ra}) and (defined $c->{dec}) and (defined $c->{roll})){
-	printf $OUT "../make_stars.pl -starcat starcat.dat.$format", $c->{obsid};
-	print $OUT " -ra $c->{ra} -dec $c->{dec} -roll $c->{roll} ";
-	print $OUT "-sim_z $c->{SIM_OFFSET_Z} " if ($c->{SIM_OFFSET_Z});
-	print $OUT "-si $c->{SI} " if ($c->{SI});
-	print $OUT "\n";
-    }
-}
-close($OUT);
-
 # Write the HTML
 
 if ($par{html}) {
@@ -832,7 +816,6 @@ if ($par{html}) {
     print STDERR "Wrote HTML report to $STARCHECK.html\n";
 
     my $guide_summ_start = 'PROCESSING SOCKET REQUESTS';
-    make_annotated_file('', 'starcat.dat.', ' -ra ', $make_stars);
     make_annotated_file('', ' ID=\s+', ', ', $backstop);
     make_annotated_file($guide_summ_start, '^\s+ID:\s+', '\S\S', $guide_summ);
     make_annotated_file('', '^ ID=', ', ', $or_file) if ($or_file);


### PR DESCRIPTION
## Description

Remove all make_stars stuff

This includes an update to the load review checklist.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
     - has no unit tests
- [x] Functional testing 
     - ran on a recent week and see expected lack of make_stars

