### PR TITLE
Remove special case ER checks

### DIFF
--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -208,22 +208,6 @@ Checks
 |       |                  | | |configuration (2    |      |     |    |    |    |                |
 |       |                  | | |monitor windows)    |      |     |    |    |    |                |
 +-------+------------------+-+-+--------------------+------+-----+----+----+----+----------------+
-|       |                  |X|X|Special Case Engineering Request           |    |                |
-|       |                  | | |(immediately follows an OR at identical    |    |                |
-|       |                  | | |attitude, duration in NPM <= 10 min )      |    |                |
-|       |                  | | +--------------------+------+-----+----+----+    |AS:             |
-|       |                  | | |Special Case ER     | #FL  | #AS |#GS |#MW |    |                |
-|       |                  | | |                    |      |     |    |    |    |Possible Bright |
-|       |                  | | +--------------------+------+-----+----+----+    |Star Hold       |
-|ACA-044|Star catalog      | | |Requirements        |  0   | >=4 |>=4 |<=1 |n/a |                |
-|       |                  | | +--------------------+------+-----+----+----+    |GS:             |
-|       |                  | | |Standard            |  0   | 5-8 |6-8 | 0  |    |                |
-|       |                  | | |configuration       |      |     |    |    |    |Reduced aspect  |
-|       |                  | | +--------------------+------+-----+----+----+    |quality         |
-|       |                  | | |Alternate           |  0   | 4-8 |5-7 | 1  |    |                |
-|       |                  | | |configuration       |      |     |    |    |    |                |
-|       |                  | | |(monitor window)    |      |     |    |    |    |                |
-+-------+------------------+-+-+--------------------+------+-----+----+----+----+----------------+
 |ACA-009|Magnitude limit   |X|X|AS: 5.8 - 10.3 (or fainter, if needed to   |n/a |Possible Bright |
 |       |                  | | |find stars)                                |    |Star Hold       |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1145,37 +1145,6 @@ sub check_momentum_unload{
     }
 }
 
-#############################################################################################
-sub check_for_special_case_er{
-#############################################################################################
-    my $self = shift;
-    # if the previous obsid is an OR and the current one is an ER
-    # and the obsid is < 10 minutes in duration (we've got a <10 min NPM criterion)
-    # and there is a star catalog to check
-    # and the last obsid had a star catalog
-    # and the pointings are the same
-    # it is a special case ER
-    $self->{special_case_er} = 0;
-    if ($self->{obsid} =~ /^\d+$/
-        and $self->{obsid} >= $ER_MIN_OBSID
-        and $self->find_command("MP_STARCAT")
-        and $self->{prev}
-        and $self->{prev}->{obsid} =~ /^\d+$/
-        and $self->{prev}->{obsid} < $ER_MIN_OBSID
-        and $self->{prev}->find_command("MP_STARCAT")
-        and abs($self->{ra} - $self->{prev}->{ra}) < 0.001
-        and abs($self->{dec} - $self->{prev}->{dec}) < 0.001
-        and abs($self->{roll} - $self->{prev}->{roll}) < 0.001){
-        if (($self->{obs_tstop} - $self->{obs_tstart}) < 10*60){
-            $self->{special_case_er} = 1;
-            push @{$self->{fyi}}, "Special Case ER\n";
-        }
-        else{
-            push @{$self->{fyi}},
-            sprintf("Same attitude as last obsid but too long (%.1f min) for Special Case ER\n", ($self->{obs_tstop} - $self->{obs_tstart})/60.);
-        }
-    }
-}
 
 #############################################################################################
 sub check_sim_position {

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -536,7 +536,6 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->check_star_catalog($or{$obsid}, $par{vehicle});
     $obs{$obsid}->check_sim_position(@sim_trans) unless $par{vehicle};
 	$obs{$obsid}->check_momentum_unload(\@bs);
-    $obs{$obsid}->check_for_special_case_er();
     $obs{$obsid}->check_bright_perigee($radmon);
 
 # Make sure there is only one star catalog per obsid
@@ -692,11 +691,6 @@ for my $obs_idx (0 .. $#obsid_id) {
 
         # minumum requirements for fractional guide star count for ERs and ORs
         my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000 ) ? 6.0 : 4.0;
-
-        # use the 'special case' ER rules from ACA-044
-        if ($obs{$obsid}->{special_case_er}){
-            $min_num_gui = 4.0;
-        }
 
         # Use the acq prob model values saved in figure_of_merit for the expected
         # number of acq stars and a bad overall probability.  figure_of_merit isn't


### PR DESCRIPTION
## Description

Remove special case ER checks

I've left this in the load review checklist, so if it comes up again we can revisit using those rules.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
   - No unit tests
- [x] Functional testing
   - Ran on a recent schedule without erroring out

Fixes #