### PR TITLE
Remove multiple star filter stuff

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -42,7 +42,6 @@ use Inline Python => q{
 import os
 import traceback
 
-from chandra_aca.star_probs import set_acq_model_ms_filter
 from starcheck.pcad_att_check import check_characteristics_date
 from starcheck.utils import (_make_pcad_attitude_check_report,
                              plot_cat_wrapper,
@@ -257,10 +256,6 @@ Ska::Starcheck::Obsid::set_odb(%odb);
 
 
 Ska::Starcheck::Obsid::set_config($config_ref);
-
-# Set the multple star filter disabled in the model if after this date
-my $MSF_ENABLED = $bs[0]->{date} lt '2016:102:00:00:00.000';
-set_acq_model_ms_filter($MSF_ENABLED);
 
 # Read Maneuver error file containing more accurate maneuver errors
 my @manerr;
@@ -609,9 +604,6 @@ if (%input_files) {
 	$out .= "Using ACABadPixel file from $ACA_badpix_date Dark Cal \n";
 	$save_hash{run}{badpix} = $ACA_badpix_date;
     }
-
-    $out .= "Using acquisition model for multiple star filter "
-        . ($MSF_ENABLED ? "enabled\n" : "disabled\n");
 
     $out .= "\n";
 }

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from Chandra.Time import DateTime
 from Chandra.Time import secs2date as time2date, date2secs as pydate2secs
-from chandra_aca.star_probs import set_acq_model_ms_filter
 import starcheck
 from starcheck.pcad_att_check import make_pcad_attitude_check_report, check_characteristics_date
 from starcheck.calc_ccd_temps import get_ccd_temps


### PR DESCRIPTION
## Description

Remove code that set and printed multiple star status in the acquisition model.

I think this is all OBE with the grid model.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
   - No unit tests
- [x] Functional testing
   - Passes on a recent schedule with no star catalog diffs

Fixes #