### PR TITLE
Recharacterize too few guide warning as yellow warn

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1368,7 +1368,7 @@ sub check_star_catalog {
     push @warn,"Too Few Acquisition Stars\n" if (@{$self->{acq}} < $min_acq);
     # Red warn if fewer than the minimum number of guide stars
     my $n_gui = @{$self->{gui}};
-    push @warn,"Only $n_gui Guide Stars ($min_guide required)\n" if ($n_gui < $min_guide);
+    push @yellow_warn,"Only $n_gui Guide Stars ($min_guide required)\n" if ($n_gui < $min_guide);
     push @warn,"Too Many GUIDE + FID\n" if (@{$self->{gui}} + @{$self->{fid}} + @{$self->{mon}} > 8);
     push @warn,"Too Many Acquisition Stars\n" if (@{$self->{acq}} > 8);
     push @warn,"Too many MON\n" if ((@{$self->{mon}} > 1 && $is_science) ||


### PR DESCRIPTION
## Description

Recharacterize too few guide warning as yellow warn

This changes a red warning on too few commanded guide stars to a yellow warning.  The guide count will be the limiting/red check in these cases.  I don't think this needs a load review checklist update (it notes requirements >= 4 and standard configuration = 5).

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
   - No unit tests
- [x] Functional testing
   - Ran on DEC0720 and confirmed critical ">> CRITICAL: Only 4 Guide Stars (5 required)" is now a CAUTION

Fixes #