### PR TITLE
Get ACA planning and penalty limits from chandra_models

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -40,6 +40,7 @@ import xija
 from chandra_aca import dark_model
 from parse_cm import read_or_list
 from chandra_aca.drift import get_aca_offsets
+import proseco.characteristics as proseco_char
 
 from starcheck import __version__ as version
 
@@ -147,6 +148,7 @@ def get_ccd_temps(oflsdir, outdir='out',
                 % (TASK_NAME, proc['execution_time'], proc['run_user']))
     logger.info("# Continuity run_start_time = {}".format(run_start_time.date))
     logger.info('# {} version = {}'.format(TASK_NAME, VERSION))
+    logger.info(f'# chandra_models version = {proseco_char.chandra_models_version}')
     logger.info(f'# kadi version = {kadi.__version__}')
     logger.info('###############################'
                 '######################################\n')
@@ -220,7 +222,7 @@ def get_ccd_temps(oflsdir, outdir='out',
         ccd_times, ccd_temps = mock_telem_predict(states)
 
     make_check_plots(outdir, states, ccd_times, ccd_temps,
-                     tstart=bs_start.secs, tstop=sched_stop.secs)
+                     tstart=bs_start.secs, tstop=sched_stop.secs, char=proseco_char)
     intervals = get_obs_intervals(sc_obsids)
     obsreqs = None if orlist is None else {obs['obsid']: obs for obs in read_or_list(orlist)}
     obstemps = get_interval_data(intervals, ccd_times, ccd_temps, obsreqs)
@@ -543,7 +545,7 @@ def plot_two(fig_id, x, y, x2, y2,
     return {'fig': fig, 'ax': ax, 'ax2': ax2}
 
 
-def make_check_plots(outdir, states, times, temps, tstart, tstop):
+def make_check_plots(outdir, states, times, temps, tstart, tstop, char):
     """
     Make output plots.
 

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -552,7 +552,6 @@ def make_check_plots(outdir, states, times, temps, tstart, tstop, char):
     :param tstop: schedule stop time (secs)
     :rtype: dict of review information including plot file names
     """
-
     plots = {}
 
     # Start time of loads being reviewed expressed in units for plotdate()

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -80,8 +80,6 @@ def get_options():
                         help="output destination for temperature JSON, file or stdout")
     parser.add_argument("--model-spec",
                         help="xija ACA model specification file")
-    parser.add_argument("--char-file",
-                        help="starcheck characteristics file")
     parser.add_argument("--orlist",
                         help="OR list")
     parser.add_argument("--traceback",
@@ -100,7 +98,7 @@ def get_options():
 
 def get_ccd_temps(oflsdir, outdir='out',
                   json_obsids=None,
-                  model_spec=None, char_file=None, orlist=None,
+                  model_spec=None, orlist=None,
                   run_start_time=None,
                   verbose=1, **kwargs):
     """
@@ -113,7 +111,6 @@ def get_ccd_temps(oflsdir, outdir='out',
     :param json_obsids: file-like object or string containing JSON of
                         starcheck Obsid objects (default='<oflsdir>/starcheck/obsids.json')
     :param model_spec: xija ACA model spec file (default=package aca_spec.json)
-    :param char_file: starcheck characteristics file (default=package characteristics.yaml)
     :param run_start_time: Chandra.Time date, clock time when starcheck was run,
                      or a user-provided value (usually for regression testing).
     :param verbose: Verbosity (0=quiet, 1=normal, 2=debug)
@@ -127,8 +124,6 @@ def get_ccd_temps(oflsdir, outdir='out',
     module_dir = Path(__file__).parent
     if model_spec is None:
         model_spec = str(module_dir / 'data' / 'aca_spec.json')
-    if char_file is None:
-        char_file = str(module_dir / 'data' / 'characteristics.yaml')
 
     if json_obsids is None:
         # Only happens in testing, so use existing obsids file in OFLS dir
@@ -557,7 +552,6 @@ def make_check_plots(outdir, states, times, temps, tstart, tstop, char):
     :param tstop: schedule stop time (secs)
     :rtype: dict of review information including plot file names
     """
-    import proseco.characteristics as char
 
     plots = {}
 

--- a/starcheck/data/characteristics.yaml
+++ b/starcheck/data/characteristics.yaml
@@ -1,8 +1,2 @@
 paths:
    week_lookup: https://icxc.harvard.edu/cgi-bin/aspect/starcheck/find_shortterm.cgi
-
-ccd_temp_yellow_limit: -7.5
-ccd_temp_red_limit: -6.5
-
-n100_warm_frac_default: .20
-

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -489,7 +489,6 @@ $json_obsid_temps = ccd_temp_wrapper({oflsdir=> $par{dir},
                                       outdir=>$STARCHECK,
                                       json_obsids => $json_text,
                                       model_spec => "$Starcheck_Data/aca_spec.json",
-                                      char_file => "$Starcheck_Data/characteristics.yaml",
                                       orlist => $or_file,
                                       run_start_time => $run_start_time,
                                   });

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -1,4 +1,5 @@
 import os
+import functools
 import numpy as np
 
 from Chandra.Time import DateTime
@@ -6,8 +7,26 @@ from Chandra.Time import secs2date as time2date, date2secs as pydate2secs
 import starcheck
 from starcheck.pcad_att_check import make_pcad_attitude_check_report, check_characteristics_date
 from starcheck.calc_ccd_temps import get_ccd_temps
+from starcheck.plot import make_plots_for_obsid
 from starcheck import __version__ as version
 from kadi.commands import states
+
+
+def print_traceback_on_exception(func):
+    """Decorator to print a stack trace on exception.
+
+    The default perl inline suppresses this stack trace which makes debugging
+    difficult.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            raise
+    return wrapper
 
 
 # Borrowed from https://stackoverflow.com/a/33160507
@@ -25,45 +44,38 @@ def de_bytestr(data):
     return data
 
 
+@print_traceback_on_exception
 def date2time(date):
     return pydate2secs(de_bytestr(date))
 
 
+@print_traceback_on_exception
 def ccd_temp_wrapper(kwargs):
-    try:
-        return get_ccd_temps(**de_bytestr(kwargs))
-    except Exception:
-        import traceback
-        traceback.print_exc()
-        raise
+    return get_ccd_temps(**de_bytestr(kwargs))
 
 
+@print_traceback_on_exception
 def plot_cat_wrapper(kwargs):
-    try:
-        from starcheck.plot import make_plots_for_obsid
-    except ImportError as err:
-        # write errors to starcheck's global warnings and STDERR
-        perl.warning("Error with Inline::Python imports {}\n".format(err))
     return make_plots_for_obsid(**de_bytestr(kwargs))
 
 
+@print_traceback_on_exception
 def starcheck_version():
     return version
 
 
+@print_traceback_on_exception
 def get_data_dir():
     sc_data = os.path.join(os.path.dirname(starcheck.__file__), 'data')
     return sc_data if os.path.exists(sc_data) else ""
 
 
+@print_traceback_on_exception
 def _make_pcad_attitude_check_report(kwargs):
-    try:
-        return make_pcad_attitude_check_report(**de_bytestr(kwargs))
-    except Exception:
-        import traceback
-        traceback.print_exc()
+    return make_pcad_attitude_check_report(**de_bytestr(kwargs))
 
 
+@print_traceback_on_exception
 def get_dither_kadi_state(date):
     date = date.decode('ascii')
     cols = ['dither', 'dither_ampl_pitch', 'dither_ampl_yaw',
@@ -78,6 +90,7 @@ def get_dither_kadi_state(date):
     return state
 
 
+@print_traceback_on_exception
 def get_run_start_time(run_start_time, backstop_start):
     """
     Determine a reasonable reference run start time based on the supplied

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -59,8 +59,9 @@ def get_data_dir():
 def _make_pcad_attitude_check_report(kwargs):
     try:
         return make_pcad_attitude_check_report(**de_bytestr(kwargs))
-    except Exception as err:
-        perl.warning("Error running dynamic attitude checks {}\n".format(err))
+    except Exception:
+        import traceback
+        traceback.print_exc()
 
 
 def get_dither_kadi_state(date):


### PR DESCRIPTION
## Description

This uses the `proseco.characteristics` module to get the ACA planning and penalty limits from the latest release of `chandra_models` in `$SKA/data/chandra_models`.

This also includes an improvement to the exception handling for some Python functions that get called from perl.

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing of planning limit

Used local dev version of proseco (https://github.com/sot/proseco/pull/356) @ f889746 along with a local version of `chandra_models` that has https://github.com/sot/chandra_models/pull/74 @ edcec9a. With this:
```
(ska3) ➜  starcheck git:(master) ✗ ./sandbox_starcheck -dir ~/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa
Using backstop file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/CR165_0005.backstop
Using guide summary file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/mps/mgJUN1421A.sum
Using OR file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/mps/or/JUN1421_A.or
Using maneuver file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/mps/mmJUN1421A.sum
Using DOT file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/mps/mdJUN1421A.dot
Using mech check file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/output/TEST_mechcheck.txt
Using fidsel file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/History/FIDSEL.txt
Using dither file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/History/DITHER.txt
Using radmon file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/History/RADMON.txt
Using simtrans file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/History/SIMTRANS.txt
Using simfocus file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/History/SIMFOCUS.txt
Using attitude file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/History/ATTITUDE.txt
Using characteristics file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/mps/ode/characteristics/CHARACTERIS_18JAN21
Using aimpoint file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/output/JUN1421A_dynamical_offsets.txt
Using config file /Users/aldcroft/git/starcheck/starcheck/data/characteristics.yaml
Using odb file /Users/aldcroft/git/starcheck/starcheck/data/fid_CHARACTERISTICS
Using agasc_file file /Users/aldcroft/ska/data/agasc/proseco_agasc_1p7.h5
Using manerr file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/output/JUN1421A_ManErr.txt
Using processing summary file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/mps/msJUN1421A.sum
Using TLR file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/CR165_0005.tlr
Using banned_agasc file /Users/aldcroft/git/starcheck/starcheck/data/agasc.bad
Using bad_pixel file /Users/aldcroft/git/starcheck/starcheck/data/ACABadPixels
Using acq_star_rdb file /Users/aldcroft/git/starcheck/starcheck/data/bad_acq_stars.rdb
Using gui_star_rdb file /Users/aldcroft/git/starcheck/starcheck/data/bad_gui_stars.rdb
Read 246 ACA bad pixels from /Users/aldcroft/git/starcheck/starcheck/data/ACABadPixels
Read 46 bad AGASC IDs from /Users/aldcroft/git/starcheck/starcheck/data/agasc.bad
#####################################################################
# calc_ccd_temps run at Thu Jun 24 17:50:46 2021 by aldcroft
# Continuity run_start_time = 2021:175:21:50:46.268
# calc_ccd_temps version = 13.10.1.dev2+g0382316.d20210624
# kadi version = 5.6.0
#####################################################################

Using backstop file /Users/aldcroft/ska/data/mpcrit1/mplogs/2021/JUN1421/oflsa/CR165_0005.backstop
Found 1624 backstop commands between 2021:164:23:57:54.550 and 2021:172:05:35:12.589
RLTT = 2021:165:00:00:54.550
sched_stop = 2021:172:05:35:12.589
Fetching telemetry between 2021:163:23:57:54.550 and 2021:164:23:57:54.550
Calculating ACA thermal model
Propagation initial time and ACA: 2021:164:23:43:18.816 -9.13
Making temperature check plots
Writing plot file starcheck/ccd_temperature.png
Checking star catalog for obsid 46290
Checking star catalog for obsid 22518
Checking star catalog for obsid 46289
Checking star catalog for obsid 46288
Checking star catalog for obsid 46287
Checking star catalog for obsid 46286
Checking star catalog for obsid 46285
Checking star catalog for obsid 25062
Checking star catalog for obsid 25017
Checking star catalog for obsid 23612
Checking star catalog for obsid 25026
Checking star catalog for obsid 23410
Checking star catalog for obsid 24266
Checking star catalog for obsid 22980
Checking star catalog for obsid 24458
Checking star catalog for obsid 46284
Checking star catalog for obsid 46283
Checking star catalog for obsid 46282
Checking star catalog for obsid 46281
Checking star catalog for obsid 46280
Checking star catalog for obsid 46279
Checking star catalog for obsid 22519
Checking star catalog for obsid 23807
Checking star catalog for obsid 25041
Checking star catalog for obsid 24710
Checking star catalog for obsid 25063
Checking star catalog for obsid 46278
Checking star catalog for obsid 25050
Checking star catalog for obsid 23607
Checking star catalog for obsid 22450
Checking star catalog for obsid 25064
Checking star catalog for obsid 46277
Checking star catalog for obsid 46276
Checking star catalog for obsid 46275
Checking star catalog for obsid 46274
Checking star catalog for obsid 46273
Checking star catalog for obsid 46272
Checking star catalog for obsid 22594
Checking star catalog for obsid 23589
Checking star catalog for obsid 23563
Checking star catalog for obsid 23567
Checking star catalog for obsid 24732
Checking star catalog for obsid 22595
Wrote HTML report to starcheck.html
Wrote text report to starcheck.txt
```
The output shows the red and yellow limits lines at -5.8 and -6.8 C respectively, and shows expected INFO messages like `>> INFO    : Effective acq temperature -5.6 C`.

### Functional testing of exception handling

Modified one function that is wrapped in the new decorator to raise an exception (`return 1 / 0`) and confirmed the expected output and stop to processing.
