### PR TITLE
WIP Move the bright limit warnings by 0.6 mags

### DIFF
--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -208,10 +208,10 @@ Checks
 |       |                  | | |configuration (2    |      |     |    |    |    |                |
 |       |                  | | |monitor windows)    |      |     |    |    |    |                |
 +-------+------------------+-+-+--------------------+------+-----+----+----+----+----------------+
-|ACA-009|Magnitude limit   |X|X|AS: 5.8 - 10.3 (or fainter, if needed to   |n/a |Possible Bright |
+|ACA-009|Magnitude limit   |X|X|AS: 5.2 - 10.3 (or fainter, if needed to   |n/a |Possible Bright |
 |       |                  | | |find stars)                                |    |Star Hold       |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
-|ACA-010|Magnitude limit   |X|X|GS: 6.0 - 10.3 (or fainter, if needed to   |n/a |Reduced aspect  |
+|ACA-010|Magnitude limit   |X|X|GS: 5.4 - 10.3 (or fainter, if needed to   |n/a |Reduced aspect  |
 |       |                  | | |find stars)                                |    |quality         |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
 |ACA-011|Magnitude limit   |X|X|FL: 6.8 - 7.2                              |n/a |Reduced aspect  |

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1524,13 +1524,13 @@ sub check_star_catalog {
 	if ($mag ne '---') {
             if ($type eq 'GUI' or $type eq 'BOT'){
                 my $guide_mag_warn = sprintf "[%2d] Magnitude. Guide star %6.3f\n", $i, $mag;
-                if (($mag > 10.3) or ($mag < 6.0)){
+                if (($mag > 10.3) or ($mag < 5.4)){
                     push @warn, $guide_mag_warn;
                 }
             }
             if ($type eq 'BOT' or $type eq 'ACQ'){
                 my $acq_mag_warn = sprintf "[%2d] Magnitude. Acq star %6.3f\n", $i, $mag;
-                if ($mag < 5.8){
+                if ($mag < 5.2){
                     push @warn, $acq_mag_warn;
                 }
                 elsif ($mag > $self->{mag_faint_red}){


### PR DESCRIPTION
## Description

WIP Move the bright limit warnings by 0.6 mags

Not sure how much we want to finesse the limits for the load review checklist and the starcheck warning (or just defer to the sparkles warning based on sigmag)... or if we should just push them brighter by 0.6 mags.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

