### PR TITLE
round guide count and P2

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2619,6 +2619,19 @@ sub quat2radecroll {
     return ($ra, $dec, $roll);
 }
 
+###################################################################################
+sub check_guide_count{
+###################################################################################
+    my $self = shift;
+    my $guide_count = $self->count_guide_stars();
+
+    if ($guide_count < 4.0){
+        push @{$self->{warn}}, "Guide count of $guide_count < 4.0.";
+    }
+
+    # Also save the guide count in the figure_of_merit
+    $self->{figure_of_merit}->{guide_count} = $guide_count;
+}
 
 ###################################################################################
 sub count_guide_stars{

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2630,8 +2630,10 @@ sub check_guide_count{
     my $self = shift;
     my $guide_count = $self->count_guide_stars();
 
-    if ($guide_count < 4.0){
-        push @{$self->{warn}}, "Guide count of $guide_count < 4.0.";
+    my $min_num_gui = ($self->{obsid} >= 38000 ) ? 6.0 : 4.0;
+
+    if ($guide_count < $min_num_gui){
+        push @{$self->{warn}}, "Guide count of $guide_count < $min_num_gui.";
     }
 
     # Also save the guide count in the figure_of_merit

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1120,6 +1120,7 @@ sub check_bright_perigee{
 	push @{$self->{warn}}, "$bright_count star(s) brighter than scaled 9th mag. "
 	    . "Perigee requires at least $min_n_stars\n";
     }
+    $self->{figure_of_merit}->{guide_count_9th} = $bright_count;
 }
 
 
@@ -2272,9 +2273,12 @@ sub print_report {
         $o .= sprintf("%.1f", $self->{figure_of_merit}->{P2}) . "\t";
 	$o .= "$font_stop" if $bad_FOM;
 	$o .= "\n";
-	$o .= sprintf("Acquisition Stars Expected  : %.2f\tGuide star count: %.1f \n",
-                      $self->{figure_of_merit}->{expected},
-                      $self->{figure_of_merit}->{guide_count});
+	$o .= sprintf("Acquisition Stars Expected  : %.2f\n", $self->{figure_of_merit}->{expected});
+	$o .= sprintf("Guide star count: %.1f \t", $self->{figure_of_merit}->{guide_count});
+	if (defined $self->{figure_of_merit}->{guide_count_9th}){
+	    $o .= sprintf("Guide count_9th: %.1f", $self->{figure_of_merit}->{guide_count_9th});
+	}
+	$o .= "\n";
     }
 
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2457,7 +2457,7 @@ sub identify_stars {
             my $gs_mag = $c->{"GS_MAG$i"};
             my $dmag = abs($star->{mag_aca} - $gs_mag);
             if ($dmag > 0.01){
-                push @{$self->{warn}},
+                push @{$self->{yellow_warn}},
                     sprintf("[%d] Guide sum mag diff from agasc mag %9.5f\n", $i, $dmag);
             }
 	    # let's still confirm that the backstop yag zag is what we expect

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2269,7 +2269,7 @@ sub print_report {
 	my $bad_FOM = $self->{figure_of_merit}->{cum_prob_bad};
 	$o .= "$red_font_start" if $bad_FOM;
 	$o .= "Probability of acquiring 2 or fewer stars (10^-x):\t";
-        $o .= substr(sprintf("%.4f", $self->{figure_of_merit}->{P2}), 0, 6) . "\t";
+        $o .= substr(sprintf("%.1f", $self->{figure_of_merit}->{P2}), 0, 3) . "\t";
 	$o .= "$font_stop" if $bad_FOM;
 	$o .= "\n";
 	$o .= sprintf("Acquisition Stars Expected  : %.2f\n",

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1115,7 +1115,7 @@ sub check_bright_perigee{
     }
 
     # Pass 1 to _guide_count as third arg to use the count_9th mode
-    my $bright_count = _guide_count(\@mags, $self->{ccd_temp}, 1);
+    my $bright_count = sprintf("%.1f", _guide_count(\@mags, $self->{ccd_temp}, 1));
     if ($bright_count < $min_n_stars){
 	push @{$self->{warn}}, "$bright_count star(s) brighter than scaled 9th mag. "
 	    . "Perigee requires at least $min_n_stars\n";
@@ -2634,7 +2634,7 @@ sub count_guide_stars{
             push @mags, $mag;
 	}
     }
-    return _guide_count(\@mags, $self->{ccd_temp});
+    return sprintf("%.1f", _guide_count(\@mags, $self->{ccd_temp}));
 }
 
 
@@ -2849,6 +2849,8 @@ sub set_proseco_probs_and_check_P2{
         return;
     }
     my ($p_acqs, $P2, $expected) = proseco_probs($args);
+
+    $P2 = sprintf("%.1f", $P2);
 
     my @acq_indexes = @{$args->{acq_indexes}};
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2269,7 +2269,7 @@ sub print_report {
 	my $bad_FOM = $self->{figure_of_merit}->{cum_prob_bad};
 	$o .= "$red_font_start" if $bad_FOM;
 	$o .= "Probability of acquiring 2 or fewer stars (10^-x):\t";
-        $o .= substr(sprintf("%.1f", $self->{figure_of_merit}->{P2}), 0, 3) . "\t";
+        $o .= sprintf("%.1f", $self->{figure_of_merit}->{P2}) . "\t";
 	$o .= "$font_stop" if $bad_FOM;
 	$o .= "\n";
 	$o .= sprintf("Acquisition Stars Expected  : %.2f\n",

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2272,8 +2272,9 @@ sub print_report {
         $o .= sprintf("%.1f", $self->{figure_of_merit}->{P2}) . "\t";
 	$o .= "$font_stop" if $bad_FOM;
 	$o .= "\n";
-	$o .= sprintf("Acquisition Stars Expected  : %.2f\n",
-                      $self->{figure_of_merit}->{expected});
+	$o .= sprintf("Acquisition Stars Expected  : %.2f\tGuide star count: %.1f \n",
+                      $self->{figure_of_merit}->{expected},
+                      $self->{figure_of_merit}->{guide_count});
     }
 
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -536,6 +536,7 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->check_sim_position(@sim_trans) unless $par{vehicle};
 	$obs{$obsid}->check_momentum_unload(\@bs);
     $obs{$obsid}->check_bright_perigee($radmon);
+    $obs{$obsid}->check_guide_count();
 
 # Make sure there is only one star catalog per obsid
     warning ("More than one star catalog assigned to Obsid $obsid\n")
@@ -674,7 +675,7 @@ for my $obs_idx (0 .. $#obsid_id) {
     $out .= sprintf "<A HREF=\"#obsid$obs{$obsid}->{obsid}\">OBSID = %5s</A>", $obs{$obsid}->{obsid};
     $out .= sprintf " at $obs{$obsid}->{date}   ";
 
-    my $guide_count = $obs{$obsid}->count_guide_stars();
+    my $guide_count = $obs{$obsid}->{figure_of_merit}->{guide_count};
 
     # if Obsid is numeric, print tally info
     if ($obs{$obsid}->{obsid} =~ /^\d+$/ ){


### PR DESCRIPTION
## Description

This PR adds changes to round P2 and guide count so we do not get warnings due to numerical errors (like we got in [NOV1521A](https://icxc.harvard.edu/mp/mplogs/2021/NOV1521/oflsa/starcheck.html).

## Testing

- [x] Functional testing. I ran this version on the [NOV1521A](https://icxc.harvard.edu/mp/mplogs/2021/NOV1521/oflsa/starcheck.html) loads. The result is [here](https://icxc.cfa.harvard.edu/aspect/tmp/starcheck-pr378-v3/starcheck.html), and the diff between the two starcheck files is [here](https://icxc.cfa.harvard.edu/aspect/tmp/starcheck-pr378-v3/diff.html)

