### PR TITLE
Add track overlap check

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1354,15 +1354,14 @@ sub check_star_catalog {
     # (Y and Z) of another tracked type.
     foreach my $i (1..16){
 	next if $c->{"TYPE$i"} =~ /NUL|ACQ/;
-	foreach my $j (1..16){
-	    next if $i == $j;
+	foreach my $j ($i+1..16){
 	    next if $c->{"TYPE$j"} =~ /NUL|ACQ/;
 	    my $dy = $c->{"YANG${i}"} - $c->{"YANG${j}"};
 	    my $dz = $c->{"ZANG${i}"} - $c->{"ZANG${j}"};
 	    if ((abs($dy) < 60) & (abs($dz) < 60)){
 		push @warn,
-		sprintf("[%2d] Catalog overlap. Delta y,z (%.1f,%.1f) < 60 to idx $j.\n",
-			$i, $dy, $dz);
+		sprintf("Track overlap for idxs [$i] [$j]. Delta y,z (%.1f,%.1f) < 60.\n",
+			$dy, $dz);
 	    }
 	}
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1349,6 +1349,24 @@ sub check_star_catalog {
         }
     }
 
+    # Overlap spoiler check
+    # For each 'tracked' type (GUI, BOT, FID, MON) confirm that it isn't within 60 arcsecs
+    # (Y and Z) of another tracked type.
+    foreach my $i (1..16){
+	next if $c->{"TYPE$i"} =~ /NUL|ACQ/;
+	foreach my $j (1..16){
+	    next if $i == $j;
+	    next if $c->{"TYPE$j"} =~ /NUL|ACQ/;
+	    my $dy = $c->{"YANG${i}"} - $c->{"YANG${j}"};
+	    my $dz = $c->{"ZANG${i}"} - $c->{"ZANG${j}"};
+	    if ((abs($dy) < 60) & (abs($dz) < 60)){
+		push @warn,
+		sprintf("[%2d] Catalog overlap. Delta y,z (%.1f,%.1f) < 60 to idx $j.\n",
+			$i, $dy, $dz);
+	    }
+	}
+    }
+
     # Seed smallest maximums and largest minimums for guide star box
     my $max_y = -3000;
     my $min_y = 3000;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1350,6 +1350,8 @@ sub check_star_catalog {
     }
 
     # Overlap spoiler check
+    # The PEA will drop a readout window if it overlaps with another window.  This was
+    # noticed in obsid 45890 and 45884 in NOV2921A.
     # For each 'tracked' type (GUI, BOT, FID, MON) confirm that it isn't within 60 arcsecs
     # (Y and Z) of another tracked type.
     foreach my $i (1..16){


### PR DESCRIPTION
## Description

Add track overlap check.  

The PEA discards a readout window that overlaps with another window.  Review of the guide star tracking data (for the agasc supplement update) from the NOV2921A schedule shows that a guide star was frequently lost due to overlap with another guide star window. 
 
The existing spoiler checks in selection and review have prevented most overlapping stars from occurring, but the NOV2921A star selection shows that two selectable guide stars could be selected with the existing code within 35 arcsecs and have no starcheck warning.  This PR  adds a check that two tracked items (MON, FID, GUI, BOT) are not within 60 arcsecs.

## Testing

- [x] Functional testing - Ran on NOV2921A, output https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr380/starcheck.html#obsid45890

<img width="599" alt="Screen Shot 2021-12-19 at 9 39 06 PM" src="https://user-images.githubusercontent.com/791508/146704050-199e0d17-4792-4162-a1ef-5eae21d052fc.png">
