### PR TITLE
prevent matplotlib warning

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -519,7 +519,7 @@ def plot_two(fig_id, x, y, x2, y2,
     fig = plt.figure(fig_id, figsize=figsize)
     fig.clf()
     ax = fig.add_subplot(1, 1, 1)
-    ax.plot_date(xt, y, fmt='-', linestyle=linestyle, color=color)
+    ax.plot_date(xt, y, linestyle=linestyle, color=color)
     ax.set_xlim(min(xt), max(xt))
     if ylim:
         ax.set_ylim(*ylim)
@@ -530,7 +530,7 @@ def plot_two(fig_id, x, y, x2, y2,
     ax2 = ax.twinx()
 
     xt2 = Ska.Matplotlib.cxctime2plotdate(x2)
-    ax2.plot_date(xt2, y2, fmt='-', linestyle=linestyle2, color=color2)
+    ax2.plot_date(xt2, y2, linestyle=linestyle2, color=color2)
     pad = 1
     ax2.set_xlim(min(xt) - pad, max(xt) + pad)
     if ylim2:

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -519,7 +519,7 @@ def plot_two(fig_id, x, y, x2, y2,
     fig = plt.figure(fig_id, figsize=figsize)
     fig.clf()
     ax = fig.add_subplot(1, 1, 1)
-    ax.plot_date(xt, y, linestyle=linestyle, color=color)
+    ax.plot_date(xt, y, marker='', linestyle=linestyle, color=color)
     ax.set_xlim(min(xt), max(xt))
     if ylim:
         ax.set_ylim(*ylim)
@@ -530,7 +530,7 @@ def plot_two(fig_id, x, y, x2, y2,
     ax2 = ax.twinx()
 
     xt2 = Ska.Matplotlib.cxctime2plotdate(x2)
-    ax2.plot_date(xt2, y2, linestyle=linestyle2, color=color2)
+    ax2.plot_date(xt2, y2, marker='', linestyle=linestyle2, color=color2)
     pad = 1
     ax2.set_xlim(min(xt) - pad, max(xt) + pad)
     if ylim2:


### PR DESCRIPTION
## Description

This PR prevents the warning that appeared in sot/skare3/pull/755:
```
linestyle is redundantly defined by the 'linestyle' keyword argument and the fmt string.
```
which occurs because both fmt and linestyle/color are given.


## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

Fixes #