### PR TITLE
Set linestyle via fmt in plot_two

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -508,7 +508,6 @@ def write_obstemps(output_dev, obstemps):
 
 
 def plot_two(fig_id, x, y, x2, y2,
-             linestyle='-', linestyle2='-',
              color='blue', color2='magenta',
              ylim=None, ylim2=None,
              xlabel='', ylabel='', ylabel2='',
@@ -520,9 +519,7 @@ def plot_two(fig_id, x, y, x2, y2,
     fig.clf()
     ax = fig.add_subplot(1, 1, 1)
 
-    # Override plot_date's default fmt='o' with just the linestyle we want.
-    # If we set this via linestyle and marker matplotlib will throw a warning.
-    ax.plot_date(xt, y, fmt=linestyle, color=color)
+    ax.plot_date(xt, y, fmt='-', color=color)
     ax.set_xlim(min(xt), max(xt))
     if ylim:
         ax.set_ylim(*ylim)
@@ -533,9 +530,7 @@ def plot_two(fig_id, x, y, x2, y2,
     ax2 = ax.twinx()
 
     xt2 = Ska.Matplotlib.cxctime2plotdate(x2)
-
-    # Override plot_date's default fmt='o' with just the linestyle we want.
-    ax2.plot_date(xt2, y2, fmt=linestyle2, color=color2)
+    ax2.plot_date(xt2, y2, fmt='-', color=color2)
     pad = 1
     ax2.set_xlim(min(xt) - pad, max(xt) + pad)
     if ylim2:

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -518,7 +518,6 @@ def plot_two(fig_id, x, y, x2, y2,
     fig = plt.figure(fig_id, figsize=figsize)
     fig.clf()
     ax = fig.add_subplot(1, 1, 1)
-
     ax.plot_date(xt, y, fmt='-', color=color)
     ax.set_xlim(min(xt), max(xt))
     if ylim:

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -519,7 +519,10 @@ def plot_two(fig_id, x, y, x2, y2,
     fig = plt.figure(fig_id, figsize=figsize)
     fig.clf()
     ax = fig.add_subplot(1, 1, 1)
-    ax.plot_date(xt, y, marker='', linestyle=linestyle, color=color)
+
+    # Override plot_date's default fmt='o' with just the linestyle we want.
+    # If we set this via linestyle and marker matplotlib will throw a warning.
+    ax.plot_date(xt, y, fmt=linestyle, color=color)
     ax.set_xlim(min(xt), max(xt))
     if ylim:
         ax.set_ylim(*ylim)
@@ -530,7 +533,9 @@ def plot_two(fig_id, x, y, x2, y2,
     ax2 = ax.twinx()
 
     xt2 = Ska.Matplotlib.cxctime2plotdate(x2)
-    ax2.plot_date(xt2, y2, marker='', linestyle=linestyle2, color=color2)
+
+    # Override plot_date's default fmt='o' with just the linestyle we want.
+    ax2.plot_date(xt2, y2, fmt=linestyle2, color=color2)
     pad = 1
     ax2.set_xlim(min(xt) - pad, max(xt) + pad)
     if ylim2:


### PR DESCRIPTION
## Description

Set linestyle via fmt in plot_two

The previous fix to set the marker explicitly with 'marker' still had matplotlib throwing a warning because `fmt` is set and has default of 'o' in plot_date.

## Testing

- [ n/a] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

This correctly makes the plot, still without the markers and with the linestyles... and doesn't throw any warnings in ska3-next or current ska3 flight.

![plottest3](https://user-images.githubusercontent.com/791508/152249033-afb5c405-5188-4c47-847d-fdba41fe07e1.png)

