### PR TITLE
WIP: Remove 'nonstandard dither' warning on normal mon dither

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -857,6 +857,9 @@ sub check_dither {
         }
     }
 
+    my $c = find_command($self, "MP_STARCAT");
+    my @mon_stars = grep { $c->{"TYPE$_"} eq 'MON' } (1..16);
+
 
     $self->{dither_acq} = $acq_dither;
     $self->{dither_guide} = $guide_dither;
@@ -865,8 +868,16 @@ sub check_dither {
 
     # Check for standard dither
     if ($guide_dither->{state} eq 'ENAB'){
-        if ((not standard_dither($guide_dither)) or not standard_dither($acq_dither)){
-            push @{$self->{yellow_warn}}, "Non-standard dither\n";
+	if ((not standard_dither($guide_dither)) or not standard_dither($acq_dither)){
+	    # If the acquisition dither is zero and there is a mon window that's normal.
+	    if ((scalar(@mon_stars) > 0) and standard_dither($guide_dither)
+		and ($acq_dither->{ampl_p} == 0) and ($acq_dither->{ampl_y} == 0)){
+		push @{$self->{fyi}}, "Has Monitor window dither transition\n";
+	    }
+	    else{
+		push @{$self->{yellow_warn}}, "Non-standard dither\n";
+	    }
+
         }
         if (($guide_dither->{ampl_p} != $acq_dither->{ampl_p})
                 or ($guide_dither->{ampl_y} != $acq_dither->{ampl_y})){


### PR DESCRIPTION
## Description

Remove 'nonstandard dither' warning on normal mon dither

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
Ran on MAY3022B schedule and 24483 no longer has nonstandard dither CAUTION and has new INFO statement as expected (mag diff warning expected for schedule after agasc update):
```
>> CAUTION : [ 4] Search spoiler.  529278336: Y,Z,Radial,Mag seps:  41  40  57 -0.8
>> CAUTION : [10] Search spoiler.  529799376: Y,Z,Radial,Mag seps: 164  55 173 -0.4
>> CAUTION : [4] Guide sum mag diff from agasc mag   0.01140
>> INFO    : Has Monitor window dither transition
>> INFO    : Monitor window special commanding meets requirements
>> INFO    : Reviewed with ACQ dither Y=0.0 Z=0.0 
```