### PR TITLE
Add warning on OR if min(t_ccd) < -14

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -259,6 +259,7 @@ def get_interval_data(intervals, times, ccd_temp, obsreqs=None):
             obstemps[str(interval['obsid'])] = obs
             continue
         obs['ccd_temp'] = np.max(ok_temps)
+        obs['ccd_temp_min'] = np.min(ok_temps)
         obs['ccd_temp_acq'] = np.max(ok_temps[:2])
         obs['n100_warm_frac'] = dark_model.get_warm_fracs(
             100, interval['tstart'], np.max(ok_temps))

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2694,12 +2694,19 @@ sub set_ccd_temps{
     }
     # set the temperature to the value for the current obsid
     $self->{ccd_temp} = $obsid_temps->{$self->{obsid}}->{ccd_temp};
+    $self->{ccd_temp_min} = $obsid_temps->{$self->{obsid}}->{ccd_temp_min};
     $self->{ccd_temp_acq} = $obsid_temps->{$self->{obsid}}->{ccd_temp_acq};
     $self->{n100_warm_frac} = $obsid_temps->{$self->{obsid}}->{n100_warm_frac};
     # Add info statement for limit violations
     if ($self->{ccd_temp} > $config{ccd_temp_red_limit}){
         push @{$self->{fyi}}, sprintf("CCD temperature exceeds %.1f C\n",
                                        $config{ccd_temp_red_limit});
+    }
+    # Add CRITICAL if OR and too cold as fid lights may be out of boxes
+    if (($self->{obsid} < 38000) and ($self->{ccd_temp_min} < -14.0)){
+	push @{$self->{warn}}, sprintf(
+	    "OR with min(t_ccd) %.1f < -14. Fid lights may not be tracked\n",
+	    $self->{ccd_temp_min});
     }
     # Add info for having a penalty temperature too
     if ($self->{ccd_temp} > $config{ccd_temp_yellow_limit}){


### PR DESCRIPTION
## Description
Add warning on OR if min(t_ccd) < -14.

The -14.0 is hard coded for this trivial check.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #386 

## Interface impacts
None
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Changed the in-code threshold from -14 to -4 to confirm a warning on every OR in a recent schedule.
