### PR TITLE
Minimal change to default to flight scenario for commands v2

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -42,6 +42,7 @@ from parse_cm import read_or_list
 from chandra_aca.drift import get_aca_offsets
 import proseco.characteristics as proseco_char
 from xija.get_model_spec import get_xija_model_spec
+from testr import test_helper
 
 from starcheck import __version__ as version
 
@@ -119,14 +120,11 @@ def get_ccd_temps(oflsdir, outdir='out',
 
     :returns: JSON dictionary of labeled dwell intervals with max temperatures
     """
-    # For kadi commands v2 set the default scenario to flight. This is aimed at
-    # running in production on HEAD where the commands archive is updated
-    # hourly. In this case no network resources are used.
-    #
-    # For non-HEAD machines run in an environment with KADI_SCENARIO set to ""
-    # (empty string) or a valid local scenario name in order to get recent
-    # commands using network resources.
-    os.environ.setdefault('KADI_SCENARIO', 'flight')
+    # For kadi commands v2 running on HEAD set the default scenario to flight.
+    # This is aimed at running in production where the commands archive is
+    # updated hourly. In this case no network resources are used.
+    if test_helper.on_head_network():
+        os.environ.setdefault('KADI_SCENARIO', 'flight')
 
     if not os.path.exists(outdir):
         os.mkdir(outdir)
@@ -140,6 +138,7 @@ def get_ccd_temps(oflsdir, outdir='out',
 
     run_start_time = DateTime(run_start_time)
     config_logging(outdir, verbose)
+    config_logging(outdir, verbose, 'kadi')
 
     # Store info relevant to processing for use in outputs
     proc = {'run_user': os.environ.get('USER'),
@@ -466,7 +465,7 @@ def get_telem_values(tstop, msids, days=7):
     return out
 
 
-def config_logging(outdir, verbose):
+def config_logging(outdir, verbose, name=TASK_NAME):
     """Set up file and console logger.
     See http://docs.python.org/library/logging.html
               #logging-to-multiple-destinations
@@ -484,7 +483,7 @@ def config_logging(outdir, verbose):
                 1: logging.INFO,
                 2: logging.DEBUG}.get(verbose, logging.INFO)
 
-    logger = logging.getLogger(TASK_NAME)
+    logger = logging.getLogger(name)
     logger.setLevel(loglevel)
 
     # Remove existing handlers if calc_ccd_temps is called multiple times

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -119,6 +119,15 @@ def get_ccd_temps(oflsdir, outdir='out',
 
     :returns: JSON dictionary of labeled dwell intervals with max temperatures
     """
+    # For kadi commands v2 set the default scenario to flight. This is aimed at
+    # running in production on HEAD where the commands archive is updated
+    # hourly. In this case no network resources are used.
+    #
+    # For non-HEAD machines run in an environment with KADI_SCENARIO set to ""
+    # (empty string) or a valid local scenario name in order to get recent
+    # commands using network resources.
+    os.environ.setdefault('KADI_SCENARIO', 'flight')
+
     if not os.path.exists(outdir):
         os.mkdir(outdir)
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -565,6 +565,11 @@ $out .= " Run on $date by $ENV{USER} from $hostname\n";
 $out .= " Configuration:  Using AGASC at $agasc_file\n";
 my $chandra_models_version = get_chandra_models_version();
 $out .= " chandra_models version: $chandra_models_version\n";
+my $kadi_scenario = exists($ENV{KADI_SCENARIO}) ? $ENV{KADI_SCENARIO} : "None";
+if ($kadi_scenario ne "flight") {
+    $kadi_scenario = "${red_font_start}${kadi_scenario}${font_stop}";
+}
+$out .= " Kadi scenario: $kadi_scenario\n";
 $out .= "\n";
 
 if ($mp_top_link){


### PR DESCRIPTION
## Description

For production use of starcheck (run by SOT MP on HEAD), we should use the `flight` scenario by default so that it does not use external network resources. In particular using OCCweb requires credentials that may not be available.

This uses [on_head_network()](https://github.com/sot/testr/blob/master/testr/test_helper.py#L76) to decide to default to `flight`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
#### On HEAD (kady)
```
ska3-kady$ env KADI_COMMANDS_VERSION=2 ./sandbox_starcheck -dir ~/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls
Using backstop file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/CR225_1108.backstop
Using guide summary file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/mgAUG1322A.sum
Using OR file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/or/AUG1322_A.or
Using maneuver file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/mmAUG1322A.sum
Using DOT file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/mdAUG1322A.dot
Using mech check file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/output/TEST_mechcheck.txt
Using fidsel file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/FIDSEL.txt
Using dither file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/DITHER.txt
Using radmon file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/RADMON.txt
Using simtrans file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/SIMTRANS.txt
Using simfocus file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/SIMFOCUS.txt
Using attitude file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/ATTITUDE.txt
Using characteristics file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/ode/characteristics/CHARACTERIS_18JAN21
Using aimpoint file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/output/AUG1322A_dynamical_offsets.txt
Using config file /data/baffin/tom/git/starcheck/starcheck/data/characteristics.yaml
Using odb file /data/baffin/tom/git/starcheck/starcheck/data/fid_CHARACTERISTICS
Using agasc_file file /proj/sot/ska3/flight/data/agasc/proseco_agasc_1p7.h5
Using manerr file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/output/AUG1322A_ManErr.txt
Using processing summary file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/msAUG1322A.sum
Using TLR file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/CR225_1108.tlr
Using banned_agasc file /data/baffin/tom/git/starcheck/starcheck/data/agasc.bad
Using bad_pixel file /data/baffin/tom/git/starcheck/starcheck/data/ACABadPixels
Using acq_star_rdb file /data/baffin/tom/git/starcheck/starcheck/data/bad_acq_stars.rdb
Using gui_star_rdb file /data/baffin/tom/git/starcheck/starcheck/data/bad_gui_stars.rdb
Dither status in kadi commands does not match DITHER history
Read 258 ACA bad pixels from /data/baffin/tom/git/starcheck/starcheck/data/ACABadPixels
Read 46 bad AGASC IDs from /data/baffin/tom/git/starcheck/starcheck/data/agasc.bad
#####################################################################
# calc_ccd_temps run at Mon Aug 29 06:39:37 2022 by aldcroft
# Continuity run_start_time = 2022:241:10:39:37.159
# calc_ccd_temps version = 13.15.2.dev7+ge7c6691
# chandra_models version = 3.40.2
# kadi version = 6.0.1
#####################################################################

Using backstop file /home/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/CR225_1108.backstop
Found 2255 backstop commands between 2022:225:11:37:00.000 and 2022:234:01:26:00.000
RLTT = 2022:225:11:37:00.000
sched_stop = 2022:234:01:26:00.000
Fetching telemetry between 2022:224:11:37:00.000 and 2022:225:11:37:00.000
Getting commands from archive only
Loaded /proj/sot/ska3/flight/data/kadi/cmds2.h5 with 1418496 commands
Getting commands from archive only
Getting commands from archive only
Getting commands from archive only
Calculating ACA thermal model
Propagation initial time and ACA: 2022:225:11:21:50.816 -10.37
Making temperature check plots
Writing plot file starcheck/ccd_temperature.png
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int' at line 45
 at ./starcheck/src/starcheck.pl line 37.
	main::__ANON__("TypeError: unsupported operand type(s) for +: 'NoneType' and "...) called at (eval 79) line 3
	Ska::Starcheck::Obsid::proseco_probs("__main__", "proseco_probs", HASH(0x55f98d26c3e0)) called at starcheck/src/lib/Ska/Starcheck/Obsid.pm line 2896
	Ska::Starcheck::Obsid::set_proseco_probs_and_check_P2(Ska::Starcheck::Obsid=HASH(0x55f98ecb88e8)) called at ./starcheck/src/starcheck.pl line 536
```

#### On Mac
```
(ska3) ➜  starcheck git:(commands-v2-flight-minimal) ✗ env KADI_COMMANDS_VERSION=2 ./sandbox_starcheck -dir ~/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls
Using backstop file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/CR225_1108.backstop
Using guide summary file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/mgAUG1322A.sum
Using OR file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/or/AUG1322_A.or
Using maneuver file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/mmAUG1322A.sum
Using DOT file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/mdAUG1322A.dot
Using mech check file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/output/TEST_mechcheck.txt
Using fidsel file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/FIDSEL.txt
Using dither file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/DITHER.txt
Using radmon file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/RADMON.txt
Using simtrans file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/SIMTRANS.txt
Using simfocus file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/SIMFOCUS.txt
Using attitude file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/History/ATTITUDE.txt
Using characteristics file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/ode/characteristics/CHARACTERIS_18JAN21
Using aimpoint file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/output/AUG1322A_dynamical_offsets.txt
Using config file /Users/aldcroft/git/starcheck/starcheck/data/characteristics.yaml
Using odb file /Users/aldcroft/git/starcheck/starcheck/data/fid_CHARACTERISTICS
Using agasc_file file /Users/aldcroft/ska/data/agasc/proseco_agasc_1p7.h5
Using manerr file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/output/AUG1322A_ManErr.txt
Using processing summary file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/mps/msAUG1322A.sum
Using TLR file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/CR225_1108.tlr
Using banned_agasc file /Users/aldcroft/git/starcheck/starcheck/data/agasc.bad
Using bad_pixel file /Users/aldcroft/git/starcheck/starcheck/data/ACABadPixels
Using acq_star_rdb file /Users/aldcroft/git/starcheck/starcheck/data/bad_acq_stars.rdb
Using gui_star_rdb file /Users/aldcroft/git/starcheck/starcheck/data/bad_gui_stars.rdb
Dither status in kadi commands does not match DITHER history
Read 258 ACA bad pixels from /Users/aldcroft/git/starcheck/starcheck/data/ACABadPixels
Read 46 bad AGASC IDs from /Users/aldcroft/git/starcheck/starcheck/data/agasc.bad
#####################################################################
# calc_ccd_temps run at Mon Aug 29 06:31:55 2022 by aldcroft
# Continuity run_start_time = 2022:241:10:31:55.222
# calc_ccd_temps version = 13.15.2.dev7+ge7c6691
# chandra_models version = 3.40.2
# kadi version = 6.0.1
#####################################################################

Using backstop file /Users/aldcroft/ska/data/mpcrit1/mplogs/2022/AUG1322/ofls/CR225_1108.backstop
Found 2255 backstop commands between 2022:225:11:37:00.000 and 2022:234:01:26:00.000
RLTT = 2022:225:11:37:00.000
sched_stop = 2022:234:01:26:00.000
Fetching telemetry between 2022:224:11:37:00.000 and 2022:225:11:37:00.000
Getting commands from recent only scenario=None
Getting commands from recent only scenario=None
Merging cmds_recent with archive commands from 2022:195:11:21:50.816
Loaded /Users/aldcroft/ska/data/kadi/cmds2.h5 with 1418496 commands
Selecting commands from cmds_arch[0:]
Matching blocks for (a) recent commands and (b) existing HDF5
  Match(a=0, b=0, size=1)
  Match(a=6, b=1, size=13)
  Match(a=20, b=14, size=7556)
  Match(a=7576, b=7570, size=0)
Diffs between (a) recent commands and (b) existing HDF5
  ('equal', 0, 1, 0, 1)
  ('delete', 1, 6, 1, 1)
  ('equal', 6, 19, 1, 14)
  ('delete', 19, 20, 14, 14)
  ('equal', 20, 7576, 14, 7570)
Getting commands from archive + recent scenario=None
Merging cmds_recent with archive commands from 2022:045:11:21:50.816
Getting commands from archive + recent scenario=None
Calculating ACA thermal model
Propagation initial time and ACA: 2022:225:11:21:50.816 -10.37
Making temperature check plots
Writing plot file starcheck/ccd_temperature.png
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int' at line 45
 at ./starcheck/src/starcheck.pl line 37.
        main::__ANON__("TypeError: unsupported operand type(s) for +: 'NoneType' and "...) called at (eval 78) line 3
        Ska::Starcheck::Obsid::proseco_probs("__main__", "proseco_probs", HASH(0x7fab39c76670)) called at starcheck/src/lib/Ska/Starcheck/Obsid.pm line 2896
        Ska::Starcheck::Obsid::set_proseco_probs_and_check_P2(Ska::Starcheck::Obsid=HASH(0x7faaca4640a8)) called at ./starcheck/src/starcheck.pl line 536
```
