### PR TITLE
Fix performance issue in get_fid_actions

### DIFF
--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -346,7 +346,7 @@ sub get_fid_actions {
 	# take the last thousand entries if there are more than a 1000
 	my @reduced_fidsel_text = @fidsel_text;
         if ($#fidsel_text > 1000){
-            my @reduced_fidsel_text = @fidsel_text[($#fidsel_text-1000) ... $#fidsel_text];
+            @reduced_fidsel_text = @fidsel_text[($#fidsel_text-1000) ... $#fidsel_text];
         }
 #    if ($fs_file && ($fidsel_fh = new IO::File $fs_file, "r")) {
 	for my $fidsel_line (@reduced_fidsel_text){


### PR DESCRIPTION
## Description

There was a bug in `get_fid_actions` that was causing the code to run on the entire mission fid history each time.

This fix reduces the time of that step by about 30 seconds.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I ran this for current master and this branch:
```
./sandbox_starcheck -dir ~/ska/data/mpcrit1/mplogs/2022/AUG2922/ofls
```
The diff of `starcheck.txt` was only the expected change:
```
$ diff starcheck.txt starcheck-new.txt
1,2c1,2
<  ------------  Starcheck 13.15.2.dev5+g5fd629a    -----------------
<  Run on Mon Aug 29 09:09:25 EDT 2022 by aldcroft from daze
---
>  ------------  Starcheck 13.15.2.dev5+g5fd629a.d20220829    -----------------
>  Run on Mon Aug 29 09:06:57 EDT 2022 by aldcroft from daze
```