### PR TITLE
Fix benign dither bug (Use of uninitialized value)

### DIFF
--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -94,7 +94,7 @@ sub dither {
     my $dh_file = shift;      # Dither history file name
     my $bs_arr = shift;               # Backstop array reference
     my $kadi_dither = shift;
-    my $dither_error = undef;
+    my $dither_error;
 
     my $bs;
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -277,7 +277,7 @@ my ($dither_error, $dither) = Ska::Parse_CM_File::dither($dither_file, \@bs, $ka
 my ($radmon_time_violation, $radmon) = Ska::Parse_CM_File::radmon($radmon_file, \@bs);
 
 # if dither history runs into load or kadi mismatch
-if ($dither_error ne ""){
+if (defined($dither_error)){
     warning($dither_error);
 }
 


### PR DESCRIPTION
## Description

Fix benign dither bug (Use of uninitialized value)

https://github.com/sot/starcheck/pull/390 introduced this tiny bug by checking for the empty string instead of a defined value.  We could use the empty string and change the check or update the check to use defined().  This PR uses defined().

Fixes warning:

Use of uninitialized value $dither_error in string ne at ./starcheck/src/starcheck.pl line 280.



## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing


<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran with and without this change, and with the changes in this PR the warning
```
Use of uninitialized value $dither_error in string ne at ./starcheck/src/starcheck.pl line 280.
```
is not present on a load without dither issues.  I ran on an old AUG2322 with dither mismatch with history and the dither warning printing at console and in starcheck html output is preserved and correct.
