### PR TITLE
Add a python function to get KADI_SCENARIO for printing

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -50,7 +50,8 @@ from starcheck.utils import (_make_pcad_attitude_check_report,
                              starcheck_version, get_data_dir,
                              get_chandra_models_version,
                              get_dither_kadi_state,
-                             get_run_start_time)
+                             get_run_start_time,
+                             get_kadi_scenario)
 
 };
 
@@ -565,7 +566,7 @@ $out .= " Run on $date by $ENV{USER} from $hostname\n";
 $out .= " Configuration:  Using AGASC at $agasc_file\n";
 my $chandra_models_version = get_chandra_models_version();
 $out .= " chandra_models version: $chandra_models_version\n";
-my $kadi_scenario = exists($ENV{KADI_SCENARIO}) ? $ENV{KADI_SCENARIO} : "None";
+my $kadi_scenario = get_kadi_scenario();
 if ($kadi_scenario ne "flight") {
     $kadi_scenario = "${red_font_start}${kadi_scenario}${font_stop}";
 }

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -71,6 +71,11 @@ def get_chandra_models_version():
 
 
 @print_traceback_on_exception
+def get_kadi_scenario():
+    return os.getenv('KADI_SCENARIO', default="None")
+
+
+@print_traceback_on_exception
 def get_data_dir():
     sc_data = os.path.join(os.path.dirname(starcheck.__file__), 'data')
     return sc_data if os.path.exists(sc_data) else ""


### PR DESCRIPTION
## Description

Add a python function to get KADI_SCENARIO for printing

KADI_SCENARIO does not appear to be set in the environment from Perl, so https://github.com/sot/starcheck/pull/391/commits/c49696c65563dece0c05896d3db05428c5d604a9 did not work.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran with and without KADI_SCENARIO set to flight in calc_ccd_temps and confirmed printing of None or flight.
