### PR TITLE
Add High IR Zone PCAD checks

### DIFF
--- a/starcheck/check_ir_zone.py
+++ b/starcheck/check_ir_zone.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+import kadi.commands
+import kadi.commands.states
+from cxotime import CxoTime
+
+
+def ir_zone_ok(backstop_file, out=None, pad_minutes=30):
+
+    pad_seconds = pad_minutes * 60
+
+    bs_cmds = kadi.commands.get_cmds_from_backstop(backstop_file)
+    bs_dates = bs_cmds['date']
+    ok = bs_cmds['event_type'] == 'RUNNING_LOAD_TERMINATION_TIME'
+    rltt = CxoTime(bs_dates[ok][0] if np.any(ok) else bs_dates[0])
+
+    # Scheduled stop time is the end of propagation, either the explicit
+    # time as a pseudo-command in the loads or the last backstop command time.
+    ok = bs_cmds['event_type'] == 'SCHEDULED_STOP_TIME'
+    sched_stop = CxoTime(bs_dates[ok][0] if np.any(ok) else bs_dates[-1])
+
+    # Get the states for available commands.  This automatically gets continuity.
+    state_keys = ['pcad_mode', 'obsid']
+    states = kadi.commands.states.get_states(cmds=bs_cmds, start=rltt, stop=sched_stop,
+                                             state_keys=state_keys, merge_identical=True)
+
+    perigee_cmds = bs_cmds[(bs_cmds['type'] == 'ORBPOINT')
+                           & (bs_cmds['event_type'] == 'EPERIGEE')]
+
+    all_ok = True
+    out_text = ["IR ZONE CHECKING"]
+    for perigee_time in perigee_cmds['time']:
+        ir_zone_start = perigee_time - pad_seconds
+        ir_zone_stop = perigee_time
+        out_text.append(
+            f"Checking perigee at {CxoTime(perigee_time).date}")
+        out_text.append(
+            f"  High IR Zone from {CxoTime(ir_zone_start).date} to {CxoTime(ir_zone_stop).date}")
+        ok = (states['tstart'] <= ir_zone_stop) & (states['tstop'] >= ir_zone_start)
+        for state in states[ok]:
+            out_text.append(
+                f"  state {state['datestart']} {state['datestop']} {state['pcad_mode']}")
+        if np.any(states[ok]['pcad_mode'] != 'NMAN'):
+            all_ok = False
+
+    if out is not None:
+        with open(out, 'w') as fh:
+            fh.writelines("\n".join(out_text))
+
+    return all_ok

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -51,7 +51,8 @@ from starcheck.utils import (_make_pcad_attitude_check_report,
                              get_chandra_models_version,
                              get_dither_kadi_state,
                              get_run_start_time,
-                             get_kadi_scenario)
+                             get_kadi_scenario,
+                             make_ir_check_report)
 
 };
 
@@ -607,6 +608,20 @@ if (@global_warn) {
 	$out .= $_;
     }
     $out .= qq{${font_stop}\n};
+}
+
+# Check for just NMAN during high IR Zone
+$out .= "------------  HIGH IR ZONE CHECK  -----------------\n\n";
+my $ir_report = "${STARCHECK}/high_ir_check.txt";
+my $ir_ok = make_ir_check_report({
+    backstop_file=> $backstop,
+    out=> $ir_report});
+if ($ir_ok){
+    $out .= "<A HREF=\"${ir_report}\">[OK] In NMAN during High IR Zones.</A>\n";
+}
+else{
+    $out .= "<A HREF=\"${ir_report}\">[${red_font_start}NOT OK${font_stop}]";
+    $out .= " Not in NMAN during High IR Zone.</A>\n";
 }
 
 

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -8,6 +8,7 @@ import starcheck
 from starcheck.pcad_att_check import make_pcad_attitude_check_report, check_characteristics_date
 from starcheck.calc_ccd_temps import get_ccd_temps
 from starcheck.plot import make_plots_for_obsid
+from starcheck.check_ir_zone import ir_zone_ok
 from starcheck import __version__ as version
 from kadi.commands import states
 import proseco.characteristics as proseco_char
@@ -84,6 +85,11 @@ def get_data_dir():
 @print_traceback_on_exception
 def _make_pcad_attitude_check_report(kwargs):
     return make_pcad_attitude_check_report(**de_bytestr(kwargs))
+
+
+@print_traceback_on_exception
+def make_ir_check_report(kwargs):
+    return ir_zone_ok(**de_bytestr(kwargs))
 
 
 @print_traceback_on_exception


### PR DESCRIPTION
## Description

Add High IR Zone PCAD checks

Check that there are no states with pcad_mode != 'NMAN' overlapping the High IR Zone times.

This adds a text file that just prints the pcad mode and times of all states that overlap the High IR Zone.  


## Interface impacts
Adds a new text file that will just be used to display output for starcheck.
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran on JAN3122A schedule and see expected top-level warning.
Output at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr395/test_jan3122a.html

Ran on AUG2922A schedule and see expected top-level OK. 
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr395/test_aug2922a.html

Diffs from flight (3.15.1) 
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr395/diff_aug2922a.html
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr395/diff_jan3122a.html


