### PR TITLE
Support move to 8x8 readouts for science observations

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -302,11 +302,6 @@ sub set_db_handle {
     $db_handle = $handle;
 }
 
-sub set_orsize {
-    my $or_size_int = shift;
-    $or_size = sprintf("%dx%d", $or_size_int, $or_size_int);
-}
-
 ##################################################################################
 sub setcolors {
 ##################################################################################
@@ -1623,6 +1618,8 @@ sub check_star_catalog {
 	    push @warn, sprintf "[%2d] Search Box Size. Search Box Too Large. \n",$i;
 	}
 
+    my $img_size = $ENV{PROSECO_OR_IMAGE_SIZE} || '8';
+    my $or_size = "${img_size}x${img_size}";
 	# Check that readout sizes are all as-requested for science observations ACA-027
 	if ($is_science && $type =~ /BOT|GUI|ACQ/  && $c->{"SIZE$i"} ne $or_size){
 	    push @warn, sprintf("[%2d] Readout Size. %s Should be %s\n",

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -267,7 +267,6 @@ my %bad_gui;
 my %bad_id;
 my %config;
 my $db_handle;
-my $or_size;
 
 
 1;

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -267,6 +267,7 @@ my %bad_gui;
 my %bad_id;
 my %config;
 my $db_handle;
+my $or_size;
 
 
 1;
@@ -301,6 +302,10 @@ sub set_db_handle {
     $db_handle = $handle;
 }
 
+sub set_orsize {
+    my $or_size_int = shift;
+    $or_size = sprintf("%dx%d", $or_size_int, $or_size_int);
+}
 
 ##################################################################################
 sub setcolors {
@@ -1618,14 +1623,10 @@ sub check_star_catalog {
 	    push @warn, sprintf "[%2d] Search Box Size. Search Box Too Large. \n",$i;
 	}
 
-	# Check that readout sizes are all 6x6 for science observations ACA-027
-	if ($is_science && $type =~ /BOT|GUI|ACQ/  && $c->{"SIZE$i"} ne "6x6"){
-	  if (($c->{"SIZE$i"} eq "8x8") and ($or->{HAS_MON}) and ($c->{"IMNUM$i"} == 7 )){
-	    push @{$self->{fyi}}, sprintf("[%2d] Readout Size. 8x8 Stealth MON?\n", $i);
-	  }
-	  else{
-	    push @warn, sprintf("[%2d] Readout Size. %s Should be 6x6\n", $i, $c->{"SIZE$i"});
-	  }
+	# Check that readout sizes are all as-requested for science observations ACA-027
+	if ($is_science && $type =~ /BOT|GUI|ACQ/  && $c->{"SIZE$i"} ne $or_size){
+	    push @warn, sprintf("[%2d] Readout Size. %s Should be %s\n",
+            $i, $c->{"SIZE$i"}, $or_size);
 	}
 
 	# Check that readout sizes are all 8x8 for engineering observations ACA-028

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -62,6 +62,8 @@ my $version = starcheck_version();
 
 # Set some global vars with directory locations
 my $SKA = $ENV{SKA} || '/proj/sot/ska';
+my $OR_SIZE = $ENV{PROSECO_OR_IMAGE_SIZE} || '8';
+Ska::Starcheck::Obsid::set_orsize($OR_SIZE);
 
 my %par = (dir  => '.',
 		   plot => 1,
@@ -244,8 +246,6 @@ map { warning("$_\n") } @{$error};
 if ($dot_touched_by_sausage == 0 ){
 	warning("DOT file not modified by SAUSAGE! \n");
 }
-
-
 
 Ska::Starcheck::Obsid::setcolors({ red => $red_font_start,
 				   blue => $blue_font_start,

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -62,8 +62,6 @@ my $version = starcheck_version();
 
 # Set some global vars with directory locations
 my $SKA = $ENV{SKA} || '/proj/sot/ska';
-my $OR_SIZE = $ENV{PROSECO_OR_IMAGE_SIZE} || '8';
-Ska::Starcheck::Obsid::set_orsize($OR_SIZE);
 
 my %par = (dir  => '.',
 		   plot => 1,
@@ -1185,6 +1183,14 @@ The guide star summary file is assumed to be named 'mg*.sum'.  If no file
 is found, a warning is produced but processing continues.  Multiple matches
 results in a fatal error, however.
 
+Starcheck uses the SKA environment variable to locate the default agasc file
+"${SKA}/data/agasc/proseco_agasc_1p7.h5".  If SKA is not set this defaults to
+'/proj/sot/ska'.
+
+Starcheck uses the PROSECO_OR_IMAGE_SIZE environment variable if available to
+set up the check for the appropriate readout image size in pixels for science
+observations. This variable should be set to either '6' or '8'. If not set,
+a default of '8' will be used to confirm all readout images sizes are 8x8.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
## Description

Support move to 8x8 readouts for science observations.

This includes an update to the ACA checklist to require that science observations are in 8x8 or 6x6 (that seemed reasonable instead of being out of compliance with the checklist during transition).

The starcheck update simply uses PROSECO_OR_IMAGE_SIZE or the new default of '8' to check the size on ORs.  The warning about "stealth" monitor windows is just removed as not needed.



## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
With this change, starcheck will respect the PROSECO_OR_IMAGE_SIZE environment variable to do its checks on ORs.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I set KADI_SCENARIO to flight until #400 is merged.

ska3-jeanconn-fido> env KADI_SCENARIO='flight' /home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/OFLS_testing/2022/OCT0322/oflst -out test_oct0322t

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr396/test_oct0322t.html

ska3-jeanconn-fido> env KADI_SCENARIO='flight' starcheck -dir /data/mpcrit1/mplogs/OFLS_testing/2022/OCT0322/oflst -out flight_oct0322t

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr396/flight_oct0322t.html

DIFF: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr396/diff_oct0322t.html

ska3-jeanconn-fido> env KADI_SCENARIO='flight' PROSECO_OR_IMAGE_SIZE='6' /home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT0322/oflsa -out test_6_oct0322a

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr396/test_6_oct0322a.html

ska3-jeanconn-fido> env KADI_SCENARIO='flight' /home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT0322/oflsa -out test_8_oct0322a

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr396/test_8_oct0322a.html

And after the last commit, I redid the first test output and confirmed no significant diffs:
```
ska3-jeanconn-fido> diff test_oct0322t.txt test_oct0322t_redo.txt
1,2c1,2
<  ------------  Starcheck 13.16.1.dev2+g2362a95    -----------------
<  Run on Wed Nov  2 15:11:02 EDT 2022 by jeanconn from fido.cfa.harvard.edu
---
>  ------------  Starcheck 13.16.1.dev3+g17cf448    -----------------
>  Run on Thu Nov  3 19:39:44 EDT 2022 by jeanconn from fido.cfa.harvard.edu

```
