### PR TITLE
Allow using maude for thermal model source data

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -157,10 +157,12 @@ def get_ccd_temps(oflsdir, outdir='out',
         logger.info("AACCCDPT not found in cheta archive.")
         have_cxc_telem = False
 
+    use_maude = False
     if maude == 1 or not have_cxc_telem:
         fetch.data_source.set('maude allow_subset=False')
         logger.info("Setting to use maude")
         stat = None
+        use_maude = True
     else:
         stat = '5min'
 
@@ -212,8 +214,11 @@ def get_ccd_temps(oflsdir, outdir='out',
     # Get temperature telemetry for 1 day prior to min(last available telem,
     # backstop start, run_start_time) where run_start_time is for regression
     # testing.
-    tlm_end_time = min(fetch.get_time_range('aacccdpt', format='secs')[1],
-                       bs_start.secs, run_start_time.secs)
+    if use_maude:
+        tlm_end_time = min(bs_start.secs, run_start_time.secs)
+    else:
+        tlm_end_time = min(fetch.get_time_range('aacccdpt', format='secs')[1],
+                           bs_start.secs, run_start_time.secs)
     tlm = get_telem_values(tlm_end_time, ['aacccdpt'], days=1, stat=stat)
     states = get_week_states(rltt, sched_stop, bs_cmds, tlm)
 

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -123,7 +123,7 @@ def get_ccd_temps(oflsdir, outdir='out',
         have_cxc_telem = False
 
     use_maude = False
-    if maude == 1 or not have_cxc_telem:
+    if maude or not have_cxc_telem:
         fetch.data_source.set('maude allow_subset=False')
         logger.info("Setting to use maude")
         use_maude = True

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -173,15 +173,19 @@ def get_ccd_temps(oflsdir, outdir='out',
     proc['datestart'] = bs_start.date
     proc['datestop'] = sched_stop.date
 
+    if use_maude:
+        import maude
+        dat = maude.get_msids("aacccdpt")  # returns the latest sample
+        tlm_end_time = dat["data"][0]["times"][0]
+    else:
+        times = fetch.get_time_range('aacccdpt', format='secs')
+        tlm_end_time = times[1]
+
     # Get temperature telemetry for 1 day prior to min(last available telem,
     # backstop start, run_start_time) where run_start_time is for regression
     # testing.
-    if use_maude:
-        tlm_end_time = min(bs_start.secs, run_start_time.secs)
-    else:
-        tlm_end_time = min(fetch.get_time_range('aacccdpt', format='secs')[1],
-                           bs_start.secs, run_start_time.secs)
-    tlm = get_telem_values(tlm_end_time, ['aacccdpt'], days=1,
+    end_time = min(tlm_end_time, bs_start.secs, run_start_time.secs)
+    tlm = get_telem_values(end_time, ['aacccdpt'], days=1,
                            stat=None if use_maude else '5min')
     states = get_week_states(rltt, sched_stop, bs_cmds, tlm)
 

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -161,10 +161,7 @@ def get_ccd_temps(oflsdir, outdir='out',
     if maude == 1 or not have_cxc_telem:
         fetch.data_source.set('maude allow_subset=False')
         logger.info("Setting to use maude")
-        stat = None
         use_maude = True
-    else:
-        stat = '5min'
 
     # save model_spec in out directory
     if isinstance(model_spec, dict):
@@ -219,7 +216,8 @@ def get_ccd_temps(oflsdir, outdir='out',
     else:
         tlm_end_time = min(fetch.get_time_range('aacccdpt', format='secs')[1],
                            bs_start.secs, run_start_time.secs)
-    tlm = get_telem_values(tlm_end_time, ['aacccdpt'], days=1, stat=stat)
+    tlm = get_telem_values(tlm_end_time, ['aacccdpt'], days=1,
+                           stat=None if use_maude else '5min')
     states = get_week_states(rltt, sched_stop, bs_cmds, tlm)
 
     # If the last obsid interval extends over the end of states then extend the
@@ -240,7 +238,8 @@ def get_ccd_temps(oflsdir, outdir='out',
     if rltt.date > DateTime(MODEL_VALID_FROM).date:
         ccd_times, ccd_temps = make_week_predict(model_spec, states, sched_stop)
     else:
-        ccd_times, ccd_temps = mock_telem_predict(states, stat=stat)
+        ccd_times, ccd_temps = mock_telem_predict(states,
+                                                  stat=None if use_maude else '5min')
 
     make_check_plots(outdir, states, ccd_times, ccd_temps,
                      tstart=bs_start.secs, tstop=sched_stop.secs, char=proseco_char)

--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -9,7 +9,6 @@ load_check
 This code generates backstop load review outputs for checking a Xija model.
 """
 
-import sys
 import os
 import glob
 import logging
@@ -61,40 +60,6 @@ try:
     VERSION = str(version)
 except Exception:
     VERSION = 'dev'
-
-
-def get_options():
-    import argparse
-    parser = argparse.ArgumentParser(
-        description="Get CCD temps from xija model for starcheck")
-    parser.set_defaults()
-    parser.add_argument("oflsdir",
-                        help="Load products OFLS directory")
-    parser.add_argument("--outdir",
-                        default='out',
-                        help="Output directory")
-    parser.add_argument('--json-obsids', nargs="?", type=argparse.FileType('r'),
-                        default=sys.stdin,
-                        help="JSON-ified starcheck Obsid objects, as file or stdin")
-    parser.add_argument('--output-temps', nargs="?", type=argparse.FileType('w'),
-                        default=sys.stdout,
-                        help="output destination for temperature JSON, file or stdout")
-    parser.add_argument("--model-spec",
-                        help="xija ACA model specification file")
-    parser.add_argument("--orlist",
-                        help="OR list")
-    parser.add_argument("--traceback",
-                        default=True,
-                        help='Enable tracebacks')
-    parser.add_argument("--verbose",
-                        type=int,
-                        default=1,
-                        help="Verbosity (0=quiet, 1=normal, 2=debug)")
-    parser.add_argument("--version",
-                        action='version',
-                        version=VERSION)
-    args = parser.parse_args()
-    return args
 
 
 def get_ccd_temps(oflsdir, outdir='out',
@@ -485,13 +450,6 @@ class NumpyAwareJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def write_obstemps(output_dev, obstemps):
-    """JSON write temperature predictions"""
-    jfile = output_dev
-    jfile.write(json_obstemps)
-    jfile.flush()
-
-
 def plot_two(fig_id, x, y, x2, y2,
              color='blue', color2='magenta',
              ylim=None, ylim2=None,
@@ -630,16 +588,3 @@ def globfile(pathglob):
         raise IOError('Multiple files matching %s' % pathglob)
     else:
         return files[0]
-
-
-if __name__ == '__main__':
-    opt = get_options()
-    try:
-        json_obstemps = get_ccd_temps(**vars(opt))
-        write_obstemps(opt.output_temps, json_obstemps)
-    except Exception as msg:
-        if opt.traceback:
-            raise
-        else:
-            sys.stderr.write("ERROR:{}".format(msg))
-            sys.exit(1)

--- a/starcheck/plot.py
+++ b/starcheck/plot.py
@@ -10,7 +10,7 @@ from chandra_aca.plot import bad_acq_stars, plot_stars, plot_compass
 
 
 def make_plots_for_obsid(obsid, ra, dec, roll, starcat_time, catalog, outdir,
-                         red_mag_lim=10.7, duration=0.0):
+                         red_mag_lim=10.7, duration=0.0, agasc_file=None):
     """
     Make standard starcheck plots for obsid and save as pngs with standard names.
     Writes out to stars_{obsid}.png and star_view_{obsid}.png in supplied outdir.
@@ -25,6 +25,7 @@ def make_plots_for_obsid(obsid, ra, dec, roll, starcat_time, catalog, outdir,
     :param outdir: output directory for png plot files
     :param red_mag_lim: faint limit
     :param duration: length of observation in seconds
+    :param agasc_file: agasc_file for star lookups
     """
 
     # explicitly float convert these, as we may be receiving this from Perl passing strings
@@ -35,7 +36,8 @@ def make_plots_for_obsid(obsid, ra, dec, roll, starcat_time, catalog, outdir,
     # get the agasc field once and then use it for both plots that have stars
     stars = agasc.get_agasc_cone(ra, dec,
                                  radius=1.5,
-                                 date=starcat_time)
+                                 date=starcat_time,
+                                 agasc_file=agasc_file)
     # We use the full star list for both the field plot and the main "catalog" plot
     # and we can save looking up the yang/zang positions twice if we add that content
     # to the stars in this wrapper

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -586,7 +586,7 @@ if ($kadi_scenario ne "flight") {
 }
 $out .= " Kadi scenario: $kadi_scenario\n";
 my $cheta_source = get_cheta_source();
-if ($cheta_source ne 'cheta'){
+if ($cheta_source ne 'cxc'){
     $cheta_source = "${red_font_start}${cheta_source}${font_stop}";
 }
 $out .= " cheta data source: $cheta_source\n";
@@ -1158,6 +1158,11 @@ Enable (or disable) generation of report in HTML format.  Default is HTML enable
 =item B<-[no]text>
 
 Enable (or disable) generation of report in TEXT format.  Default is TEXT enabled.
+
+=item B<-[no]maude>
+
+Use MAUDE for telemetry instead of default cheta cxc archive.
+MAUDE will also be used if no AACCCDPT telemetry can be found in cheta archive for initial conditions.
 
 =item B<-agasc_file <agasc>>
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -53,7 +53,7 @@ from starcheck.utils import (_make_pcad_attitude_check_report,
                              get_chandra_models_version,
                              get_dither_kadi_state,
                              get_run_start_time,
-                             get_kadi_scenario,
+                             get_kadi_scenario, get_cheta_source,
                              make_ir_check_report)
 
 };
@@ -74,7 +74,8 @@ my %par = (dir  => '.',
 		   config_file => "characteristics.yaml",
 		   fid_char => "fid_CHARACTERISTICS",
            verbose => 1,
-		   );
+	   maude => 0,
+    );
 
 
 GetOptions( \%par,
@@ -92,7 +93,8 @@ GetOptions( \%par,
 			'fid_char=s',
 			'config_file=s',
                         'run_start_time=s',
-			) ||
+	    'maude!',
+    ) ||
     exit( 1 );
 
 
@@ -504,7 +506,8 @@ $json_obsid_temps = ccd_temp_wrapper({oflsdir=> $par{dir},
                                       orlist => $or_file,
                                       run_start_time => $run_start_time,
                                       verbose => $par{verbose},
-                                  });
+				      maude => $par{maude},
+				     });
 # convert back from JSON outside
 $obsid_temps = JSON::from_json($json_obsid_temps);
 
@@ -582,6 +585,11 @@ if ($kadi_scenario ne "flight") {
     $kadi_scenario = "${red_font_start}${kadi_scenario}${font_stop}";
 }
 $out .= " Kadi scenario: $kadi_scenario\n";
+my $cheta_source = get_cheta_source();
+if ($cheta_source ne 'cheta'){
+    $cheta_source = "${red_font_start}${cheta_source}${font_stop}";
+}
+$out .= " cheta data source: $cheta_source\n";
 $out .= "\n";
 
 if ($mp_top_link){

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -537,7 +537,7 @@ foreach my $obsid (@obsid_id) {
                          catalog=>$cat_as_array,
                          starcat_time=>"$obs{$obsid}->{date}",
                          duration=>($obs{$obsid}->{obs_tstop} - $obs{$obsid}->{obs_tstart}),
-                         outdir=>$STARCHECK);
+                         outdir=>$STARCHECK, agasc_file=>$agasc_file);
         plot_cat_wrapper(\%plot_args);
         $obs{$obsid}->{plot_file} = "$STARCHECK/stars_$obs{$obsid}->{obsid}.png";
         $obs{$obsid}->{plot_field_file} = "$STARCHECK/star_view_$obs{$obsid}->{obsid}.png";

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -84,12 +84,15 @@ def set_kadi_scenario_default():
     if test_helper.on_head_network():
         os.environ.setdefault('KADI_SCENARIO', 'flight')
 
+
 @python_from_perl
 def get_cheta_source():
-    if starcheck.calc_ccd_temps.USE_MAUDE:
-        return 'maude'
+    sources = starcheck.calc_ccd_temps.fetch.data_source.sources()
+    if len(sources) == 1 and sources[0] == 'cxc':
+        return 'cxc'
     else:
-        return 'cheta'
+        return str(sources)
+
 
 @python_from_perl
 def get_kadi_scenario():

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -84,6 +84,12 @@ def set_kadi_scenario_default():
     if test_helper.on_head_network():
         os.environ.setdefault('KADI_SCENARIO', 'flight')
 
+@python_from_perl
+def get_cheta_source():
+    if starcheck.calc_ccd_temps.USE_MAUDE:
+        return 'maude'
+    else:
+        return 'cheta'
 
 @python_from_perl
 def get_kadi_scenario():


### PR DESCRIPTION
## Description

Allow using MAUDE for thermal model source data, with automatic selection of MAUDE if eng_archive data is not available.  This is handy on my laptop as I no longer bother with syncing the archive.  Adds an option to use maude for other systems when more up-to-date telemetry is desired.

While making it work on the laptop, I also noticed that the plotting routing was always using miniagasc.h5 instead of the supplied agasc_file, so added a fix for that.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Machines without AACCCDPT in their cheta archive will fallback to using MAUDE/maude for initial conditions for the ACA thermal model.  Also adds the "-maude" option to allow users to use MAUDE/maude if preferred (but does not change default unless the archive is missing or broken).

## Testing

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [X] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran on my OSX laptop fine with AACCCDPT no longer in eng_archive.

On fido tested with and without maude option and compared the without option to flight with expected results:

 /home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC1922/oflsa -maude -out dec1922t_maude

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr397/dec1922t_maude.html

/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC1922/oflsa -out dec1922t_cxc

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr397/dec1922t_cxc.html

starcheck -dir /data/mpcrit1/mplogs/2022/DEC1922/oflsa -out dec1922_flight

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr397/dec1922_flight.html

diff

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr397/diff.html
