### PR TITLE
Configure kadi logger globally + other refactoring

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -46,6 +46,8 @@ from starcheck.pcad_att_check import check_characteristics_date
 from starcheck.utils import (_make_pcad_attitude_check_report,
                              plot_cat_wrapper,
                              date2time, time2date,
+                             config_logging,
+                             set_kadi_scenario_default,
                              ccd_temp_wrapper,
                              starcheck_version, get_data_dir,
                              get_chandra_models_version,
@@ -71,6 +73,7 @@ my %par = (dir  => '.',
                    agasc_file => "${SKA}/data/agasc/proseco_agasc_1p7.h5",
 		   config_file => "characteristics.yaml",
 		   fid_char => "fid_CHARACTERISTICS",
+           verbose => 1,
 		   );
 
 
@@ -83,6 +86,7 @@ GetOptions( \%par,
 			'text!',
 			'yaml!',
 			'vehicle!',
+            'verbose=s',
 			'agasc_file=s',
 			'sc_data=s',
 			'fid_char=s',
@@ -106,6 +110,9 @@ my $font_stop = qq{</font>};
 
 usage( 1 )
     if $par{help};
+
+config_logging($STARCHECK, $par{verbose}, "kadi");
+set_kadi_scenario_default();
 
 # Find backstop, guide star summary, OR, and maneuver files.
 my %input_files = ();

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -501,6 +501,7 @@ $json_obsid_temps = ccd_temp_wrapper({oflsdir=> $par{dir},
                                       json_obsids => $json_text,
                                       orlist => $or_file,
                                       run_start_time => $run_start_time,
+                                      verbose => $par{verbose},
                                   });
 # convert back from JSON outside
 $obsid_temps = JSON::from_json($json_obsid_temps);

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -111,7 +111,11 @@ my $font_stop = qq{</font>};
 usage( 1 )
     if $par{help};
 
-config_logging($STARCHECK, $par{verbose}, "kadi");
+# kadi log levels are a little different and INFO (corresponding to the default
+# verbose=1) is too chatty for the default. Instead allow only verbose=0
+# (CRITICAL) or verbose=2 (DEBUG).
+my $kadi_verbose = $par{verbose} eq '2' ? '2' : '0';
+config_logging($STARCHECK, $kadi_verbose, "kadi");
 set_kadi_scenario_default();
 
 # Find backstop, guide star summary, OR, and maneuver files.

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+from pathlib import Path
 
 import numpy as np
 import proseco.characteristics as proseco_char
@@ -188,7 +189,9 @@ def config_logging(outdir, verbose, name):
     console.setFormatter(formatter)
     logger.addHandler(console)
 
+    if not Path(outdir).exists():
+        Path(outdir).mkdir(parents=True)
     filehandler = logging.FileHandler(
-        filename=os.path.join(outdir, 'run.dat'), mode='w')
+        filename=Path(outdir) / 'run.dat', mode='w')
     filehandler.setFormatter(formatter)
     logger.addHandler(filehandler)

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -1,27 +1,32 @@
-import os
 import functools
+import logging
+import os
+
 import numpy as np
-
-from Chandra.Time import DateTime
-from Chandra.Time import secs2date as time2date, date2secs as pydate2secs
-import starcheck
-from starcheck.pcad_att_check import make_pcad_attitude_check_report, check_characteristics_date
-from starcheck.calc_ccd_temps import get_ccd_temps
-from starcheck.plot import make_plots_for_obsid
-from starcheck.check_ir_zone import ir_zone_ok
-from starcheck import __version__ as version
-from kadi.commands import states
 import proseco.characteristics as proseco_char
+from Chandra.Time import DateTime
+from Chandra.Time import date2secs, secs2date
+from kadi.commands import states
+from testr import test_helper
+
+import starcheck
+from starcheck import __version__ as version
+from starcheck.calc_ccd_temps import get_ccd_temps
+from starcheck.check_ir_zone import ir_zone_ok
+from starcheck.pcad_att_check import make_pcad_attitude_check_report
+from starcheck.plot import make_plots_for_obsid
 
 
-def print_traceback_on_exception(func):
-    """Decorator to print a stack trace on exception.
+def python_from_perl(func):
+    """Decorator to facilitate calling Python from Perl inline.
 
-    The default perl inline suppresses this stack trace which makes debugging
-    difficult.
+    - Convert byte strings to unicode.
+    - Print stack trace on exceptions which perl inline suppresses.
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        args = de_bytestr(args)
+        kwargs = de_bytestr(kwargs)
         try:
             return func(*args, **kwargs)
         except Exception:
@@ -46,55 +51,62 @@ def de_bytestr(data):
     return data
 
 
-@print_traceback_on_exception
-def date2time(date):
-    return pydate2secs(de_bytestr(date))
+date2time = python_from_perl(date2secs)
+time2date = python_from_perl(secs2date)
 
 
-@print_traceback_on_exception
+@python_from_perl
 def ccd_temp_wrapper(kwargs):
-    return get_ccd_temps(**de_bytestr(kwargs))
+    return get_ccd_temps(**kwargs)
 
 
-@print_traceback_on_exception
+@python_from_perl
 def plot_cat_wrapper(kwargs):
-    return make_plots_for_obsid(**de_bytestr(kwargs))
+    return make_plots_for_obsid(**kwargs)
 
 
-@print_traceback_on_exception
+@python_from_perl
 def starcheck_version():
     return version
 
 
-@print_traceback_on_exception
+@python_from_perl
 def get_chandra_models_version():
     return proseco_char.chandra_models_version
 
 
-@print_traceback_on_exception
+@python_from_perl
+def set_kadi_scenario_default():
+    # For kadi commands v2 running on HEAD set the default scenario to flight.
+    # This is aimed at running in production where the commands archive is
+    # updated hourly. In this case no network resources are used.
+    if test_helper.on_head_network():
+        os.environ.setdefault('KADI_SCENARIO', 'flight')
+
+
+@python_from_perl
 def get_kadi_scenario():
     return os.getenv('KADI_SCENARIO', default="None")
 
 
-@print_traceback_on_exception
+@python_from_perl
 def get_data_dir():
     sc_data = os.path.join(os.path.dirname(starcheck.__file__), 'data')
     return sc_data if os.path.exists(sc_data) else ""
 
 
-@print_traceback_on_exception
+@python_from_perl
 def _make_pcad_attitude_check_report(kwargs):
-    return make_pcad_attitude_check_report(**de_bytestr(kwargs))
+    return make_pcad_attitude_check_report(**kwargs)
 
 
-@print_traceback_on_exception
+@python_from_perl
 def make_ir_check_report(kwargs):
-    return ir_zone_ok(**de_bytestr(kwargs))
+    return ir_zone_ok(**kwargs)
 
 
-@print_traceback_on_exception
+@python_from_perl
 def get_dither_kadi_state(date):
-    date = date.decode('ascii')
     cols = ['dither', 'dither_ampl_pitch', 'dither_ampl_yaw',
             'dither_period_pitch', 'dither_period_yaw']
     state = states.get_continuity(date, cols)
@@ -107,7 +119,7 @@ def get_dither_kadi_state(date):
     return state
 
 
-@print_traceback_on_exception
+@python_from_perl
 def get_run_start_time(run_start_time, backstop_start):
     """
     Determine a reasonable reference run start time based on the supplied
@@ -128,9 +140,6 @@ def get_run_start_time(run_start_time, backstop_start):
     :returns: YYYY:DOY string of reference run start time
     """
 
-    run_start_time = de_bytestr(run_start_time)
-    backstop_start = de_bytestr(backstop_start)
-
     # For the special case where run_start_time casts as a float
     # check to see if it is negative and if so, set the reference
     # time to be a time run_start_time days back from backstop start
@@ -145,3 +154,41 @@ def get_run_start_time(run_start_time, backstop_start):
         else:
             raise ValueError("Float run_start_time should be negative")
     return ref_time.date
+
+
+@python_from_perl
+def config_logging(outdir, verbose, name):
+    """Set up file and console logger.
+    See http://docs.python.org/library/logging.html
+              #logging-to-multiple-destinations
+    """
+    # Disable auto-configuration of root logger by adding a null handler.
+    # This prevents other modules (e.g. Chandra.cmd_states) from generating
+    # a streamhandler by just calling logging.info(..).
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+    rootlogger = logging.getLogger()
+    rootlogger.addHandler(NullHandler())
+
+    loglevel = {0: logging.CRITICAL,
+                1: logging.INFO,
+                2: logging.DEBUG}.get(int(verbose), logging.INFO)
+
+    logger = logging.getLogger(name)
+    logger.setLevel(loglevel)
+
+    # Remove existing handlers if calc_ccd_temps is called multiple times
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+
+    formatter = logging.Formatter('%(message)s')
+
+    console = logging.StreamHandler()
+    console.setFormatter(formatter)
+    logger.addHandler(console)
+
+    filehandler = logging.FileHandler(
+        filename=os.path.join(outdir, 'run.dat'), mode='w')
+    filehandler.setFormatter(formatter)
+    logger.addHandler(filehandler)

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -179,7 +179,7 @@ def config_logging(outdir, verbose, name):
     logger = logging.getLogger(name)
     logger.setLevel(loglevel)
 
-    # Remove existing handlers if calc_ccd_temps is called multiple times
+    # Remove existing handlers if this logger is already configured
     for handler in list(logger.handlers):
         logger.removeHandler(handler)
 
@@ -189,9 +189,8 @@ def config_logging(outdir, verbose, name):
     console.setFormatter(formatter)
     logger.addHandler(console)
 
-    if not Path(outdir).exists():
-        Path(outdir).mkdir(parents=True)
-    filehandler = logging.FileHandler(
-        filename=Path(outdir) / 'run.dat', mode='w')
+    outdir = Path(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    filehandler = logging.FileHandler(filename=outdir / 'run.dat', mode='w')
     filehandler.setFormatter(formatter)
     logger.addHandler(filehandler)


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes the issue noted on slack (#missionplanning "SOT MP run of starcheck did not generate the expected output files for the OCT1722B products"), that get_dither_kadi_state would run before `KADI_SCENARIO=flight` was set, causing HEAD starcheck to still have a network dependence for SOT MP's run of the tool.

In the course of implementing the fix, some refactoring and rework of existing code was useful.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests




### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Disabled occweb access and confirmed that master fails to use 'flight' scenario:
```
Traceback (most recent call last):
  File "/proj/sot/ska/jeanproj/git/starcheck/starcheck/utils.py", line 26, in wrapper
    return func(*args, **kwargs)
  File "/proj/sot/ska/jeanproj/git/starcheck/starcheck/utils.py", line 100, in get_dither_kadi_state
    state = states.get_continuity(date, cols)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/commands/states.py", line 1697, in get_continuity
    cmds = commands.get_cmds(start, stop, scenario=scenario)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/commands/commands.py", line 54, in get_cmds
    cmds = get_cmds_(start=start, stop=stop, inclusive_stop=inclusive_stop, **kwargs)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/commands/commands_v2.py", line 216, in get_cmds
    cmds_recent = update_archive_and_get_cmds_recent(
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/commands/commands_v2.py", line 312, in update_archive_and_get_cmds_recent
    loads = update_loads(scenario, cmd_events=cmd_events, lookback=lookback, stop=stop)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/commands/commands_v2.py", line 911, in update_loads
    contents = occweb.get_occweb_dir(dir_year_month)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/occweb.py", line 322, in get_occweb_dir
    html = get_occweb_page(path, timeout=timeout, cache=cache)
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/occweb.py", line 290, in get_occweb_page
    req.raise_for_status()  # raise exception if not 200
  File "/proj/sot/ska3/flight/lib/python3.8/site-packages/requests/models.py", line 960, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2022/SEP
HTTPError: 401 Client Error: Unauthorized for url: https://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2022/SEP at line 26
 at ./starcheck/src/starcheck.pl line 37.
	main::__ANON__("HTTPError: 401 Client Error: Unauthorized for url: https://oc"...) called at (eval 184) line 3
	main::get_dither_kadi_state("__main__", "get_dither_kadi_state", "2022:289:13:17:00.000") called at ./starcheck/src/starcheck.pl line 274
```
Confirmed that this PR (with the same disabled .netrc etc) works and that KADI_SCENARIO is set to flight before/for all kadi command queries.
```
ska3-jeanconn-fido> ./sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT1722/oflsb/ -out ob_test
Using backstop file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//CR289_1303.backstop
Using guide summary file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//mps/mgOCT1722B.sum
Using OR file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//mps/or/OCT1722_B.or
Using maneuver file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//mps/mmOCT1722B.sum
Using DOT file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//mps/mdOCT1722B.dot
Using mech check file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//output/TEST_mechcheck.txt
Using fidsel file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//History/FIDSEL.txt
Using dither file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//History/DITHER.txt
Using radmon file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//History/RADMON.txt
Using simtrans file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//History/SIMTRANS.txt
Using simfocus file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//History/SIMFOCUS.txt
Using attitude file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//History/ATTITUDE.txt
Using characteristics file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//mps/ode/characteristics/CHARACTERIS_18JAN21
Using aimpoint file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//output/OCT1722B_dynamical_offsets.txt
Using config file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/characteristics.yaml
Using odb file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/fid_CHARACTERISTICS
Using agasc_file file /proj/sot/ska3/flight/data/agasc/proseco_agasc_1p7.h5
Using manerr file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//output/OCT1722B_ManErr.txt
Using processing summary file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//mps/msOCT1722B.sum
Using TLR file /data/mpcrit1/mplogs/2022/OCT1722/oflsb//CR289_1303.tlr
Using banned_agasc file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/agasc.bad
Using bad_pixel file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/ACABadPixels
Using acq_star_rdb file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/bad_acq_stars.rdb
Using gui_star_rdb file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/bad_gui_stars.rdb
Getting commands from archive only
Loaded /proj/sot/ska3/flight/data/kadi/cmds2.h5 with 1431351 commands
Loaded /proj/sot/ska3/flight/data/kadi/cmds2.pkl with 147968 pars
Read 258 ACA bad pixels from /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/ACABadPixels
Read 46 bad AGASC IDs from /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/agasc.bad
#####################################################################
# calc_ccd_temps run at Tue Oct 18 10:36:10 2022 by jeanconn
# Continuity run_start_time = 2022:291:14:36:09.564
# calc_ccd_temps version = 13.16.1.dev3+g75cba91
# chandra_models version = 3.43
# kadi version = 7.0.2
#####################################################################

Using backstop file /data/mpcrit1/mplogs/2022/OCT1722/oflsb/CR289_1303.backstop
Found 2274 backstop commands between 2022:289:13:17:00.000 and 2022:297:11:45:00.000
RLTT = 2022:289:13:20:00.000
sched_stop = 2022:297:11:45:00.000
Fetching telemetry between 2022:288:13:17:00.000 and 2022:289:13:17:00.000
Getting commands from archive only
Getting commands from archive only
Calculating ACA thermal model
Propagation initial time and ACA: 2022:289:13:02:46.816 -8.76
Making temperature check plots
Writing plot file ob_test/ccd_temperature.png
Checking star catalog for obsid 45165
Checking star catalog for obsid 45164
Checking star catalog for obsid 45162
Checking star catalog for obsid 45161
Checking star catalog for obsid 45160
Checking star catalog for obsid 45159
Checking star catalog for obsid 26641
Checking star catalog for obsid 27505
Checking star catalog for obsid 25244
Checking star catalog for obsid 27517
Checking star catalog for obsid 27512
Checking star catalog for obsid 27514
Checking star catalog for obsid 26031
Checking star catalog for obsid 27271
Checking star catalog for obsid 27305
Checking star catalog for obsid 27306
Checking star catalog for obsid 27307
Checking star catalog for obsid 27308
Checking star catalog for obsid 27309
Checking star catalog for obsid 27310
Checking star catalog for obsid 27311
Checking star catalog for obsid 45158
Checking star catalog for obsid 45157
Checking star catalog for obsid 45156
Checking star catalog for obsid 45154
Checking star catalog for obsid 45153
Checking star catalog for obsid 45152
Checking star catalog for obsid 45151
Checking star catalog for obsid 25805
Checking star catalog for obsid 25194
Checking star catalog for obsid 27515
Checking star catalog for obsid 27511
Checking star catalog for obsid 25806
Checking star catalog for obsid 27506
Checking star catalog for obsid 25294
Checking star catalog for obsid 25310
Checking star catalog for obsid 27509
Checking star catalog for obsid 27272
Checking star catalog for obsid 27273
Checking star catalog for obsid 27312
Checking star catalog for obsid 27313
Checking star catalog for obsid 27314
Checking star catalog for obsid 27315
Checking star catalog for obsid 27316
Checking star catalog for obsid 27337
Checking star catalog for obsid 27338
Checking star catalog for obsid 27339
Checking star catalog for obsid 45150
Checking star catalog for obsid 45149
Checking star catalog for obsid 45148
Checking star catalog for obsid 45146
Checking star catalog for obsid 45145
Checking star catalog for obsid 45144
Checking star catalog for obsid 45143
Checking star catalog for obsid 25111
Checking star catalog for obsid 27510
Checking star catalog for obsid 23863
Checking star catalog for obsid 27516
Checking star catalog for obsid 27508
Checking star catalog for obsid 27513
Checking star catalog for obsid 27507
Checking star catalog for obsid 27482
Checking star catalog for obsid 25550
Checking star catalog for obsid 27317
Checking star catalog for obsid 27318
Checking star catalog for obsid 27319
Checking star catalog for obsid 27320
Checking star catalog for obsid 27321
Checking star catalog for obsid 24407
Checking star catalog for obsid 45142
Getting commands from archive only
Wrote HTML report to ob_test.html
Wrote text report to ob_test.txt
```

### Testing of 403a1d6

By default the output does not include any kadi logging output. Confirmed this with:
```
./sandbox_starcheck -dir ~/ska/data/mpcrit1/mplogs/2022/OCT1722/oflsb/ -out ob_test 
```
Also ran with `-verbose=0` and got the same results. Then ran with `-verbose=2` and got kadi `DEBUG` output:
```
...
Using acq_star_rdb file /Users/aldcroft/git/starcheck/starcheck/data/bad_acq_stars.rdb
Using gui_star_rdb file /Users/aldcroft/git/starcheck/starcheck/data/bad_gui_stars.rdb
Getting cmd_events from https://docs.google.com/spreadsheets/d/19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ/export?format=csv
Writing 53 cmd_events to /Users/aldcroft/.kadi/cmd_events.csv
Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2022/OCT with cache=False
Already have /Users/aldcroft/.kadi/loads/OCT1022A.pkl.gz
Already have /Users/aldcroft/.kadi/loads/OCT1722B.pkl.gz
Already have /Users/aldcroft/.kadi/loads/OCT2122A.pkl.gz
Already have /Users/aldcroft/.kadi/loads/OCT2422A.pkl.gz
Already have /Users/aldcroft/.kadi/loads/OCT2422B.pkl.gz
Already have /Users/aldcroft/.kadi/loads/OCT2722A.pkl.gz
Already have /Users/aldcroft/.kadi/loads/OCT3122A.pkl.gz
Getting OCCweb FOT/mission_planning/PRODUCTS/APPR_LOADS/2022/NOV with cache=False
No OCCweb directory for FOT/mission_planning/PRODUCTS/APPR_LOADS/2022/NOV
Including loads OCT1022A, OCT1722B, OCT2122A, OCT2422A, OCT2422B, OCT2722A, OCT3122A
Load OCT1022A has 2143 commands with RLTT=2022:283:02:40:34.206
Load OCT1722B has 2274 commands with RLTT=2022:289:13:20:00.000
... and so on
```

#### Previous behavior reported by @jeanconn, NO LONGER accurate
The new STDERR output has "Getting commands from archive only" whenever a call was made to kadi commands.  Seems fine.  The first call also shows when the commands were loaded (happens once) 
```
Loaded /proj/sot/ska3/flight/data/kadi/cmds2.h5 with 1431351 commands
Loaded /proj/sot/ska3/flight/data/kadi/cmds2.pkl with 147968 pars
```
This is fine as well.