### PR TITLE
Replace Inline::Python with a light Python function server

### DIFF
--- a/sandbox_starcheck
+++ b/sandbox_starcheck
@@ -23,12 +23,6 @@ then
     exit 1
 fi
 
-PERL_INLINE_DIRECTORY=`mktemp -d -t starcheck_inline.XXXXXX` || exit 1
-export PERL_INLINE_DIRECTORY
 perl -I ${DIR}/starcheck/src/lib ${DIR}/starcheck/src/starcheck.pl "$@"
 SC_STATUS=$?
-if [[ -d $PERL_INLINE_DIRECTORY && $PERL_INLINE_DIRECTORY =~ .*starcheck_inline.* ]];
-then
-    rm -r $PERL_INLINE_DIRECTORY
-fi
 exit $SC_STATUS

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -9,10 +9,6 @@ import hopper
 
 
 def check_characteristics_date(ofls_characteristics_file, ref_date=None):
-    # de_bytetring these inputs from Perl -> Python 3
-    ofls_characteristics_file = ofls_characteristics_file.decode()
-    if ref_date is not None:
-        ref_date = ref_date.decode()
     match = re.search(r'CHARACTERIS_(\d\d)([A-Z]{3})(\d\d)', ofls_characteristics_file)
     if not match:
         return False

--- a/starcheck/server.py
+++ b/starcheck/server.py
@@ -15,7 +15,8 @@ class PythonServer(socketserver.TCPServer):
     timeout = 2
 
     def handle_timeout(self) -> None:
-        print("SERVER: timeout")
+        print(f"SERVER: starcheck python server timeout after {self.timeout}s idle",
+              file=sys.stderr)
         # self.shutdown()  # DOES NOT WORK, just hangs
         sys.exit(1)
 

--- a/starcheck/server.py
+++ b/starcheck/server.py
@@ -11,6 +11,15 @@ KEY = None
 func_calls = collections.Counter()
 
 
+class PythonServer(socketserver.TCPServer):
+    timeout = 2
+
+    def handle_timeout(self) -> None:
+        print("SERVER: timeout")
+        # self.shutdown()  # DOES NOT WORK, just hangs
+        sys.exit(1)
+
+
 class MyTCPHandler(socketserver.StreamRequestHandler):
     """
     The request handler class for our server.
@@ -74,10 +83,11 @@ def main():
     print("SERVER: starting on port", port)
 
     # Create the server, binding to localhost on supplied port
-    with socketserver.TCPServer((HOST, port), MyTCPHandler) as server:
+    with PythonServer((HOST, port), MyTCPHandler) as server:
         # Activate the server; this will keep running until you
         # interrupt the program with Ctrl-C
-        server.serve_forever()
+        while True:
+            server.handle_request()
 
 
 if __name__ == "__main__":

--- a/starcheck/server.py
+++ b/starcheck/server.py
@@ -1,0 +1,64 @@
+import importlib
+import json
+import socketserver
+import traceback
+
+
+PORT = 44123
+HOST = "localhost"
+
+
+class MyTCPHandler(socketserver.StreamRequestHandler):
+    """
+    The request handler class for our server.
+
+    It is instantiated once per connection to the server, and must
+    override the handle() method to implement communication to the
+    client.
+    """
+
+    def handle(self):
+        # self.request is the TCP socket connected to the client
+        data = self.rfile.readline()
+        # print(f"SERVER receive: {data.decode('utf-8')}")
+
+        # Decode self.data from JSON
+        cmd = json.loads(data)
+        # print(f"SERVER receive func: {cmd['func']}")
+        # print(f"SERVER receive args: {cmd['args']}")
+        # print(f"SERVER receive kwargs: {cmd['kwargs']}")
+
+        # For security reasons, only allow functions in the public API of starcheck module
+        parts = cmd["func"].split(".")
+        package = '.'.join(['starcheck'] + parts[:-1])
+        func = parts[-1]
+        module = importlib.import_module(package)
+        func = getattr(module, func)
+        args = cmd["args"]
+        kwargs = cmd["kwargs"]
+
+        try:
+            result = func(*args, **kwargs)
+        except Exception:
+            result = None
+            exc = traceback.format_exc()
+        else:
+            exc = None
+
+        resp = json.dumps({"result": result, "exception": exc})
+        # print(f"SERVER send: {resp}")
+
+        self.request.sendall(resp.encode("utf-8"))
+
+
+def main():
+    # Create the server, binding to localhost on port 9999
+    with socketserver.TCPServer((HOST, PORT), MyTCPHandler) as server:
+        # Activate the server; this will keep running until you
+        # interrupt the program with Ctrl-C
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    print("SERVER: starting on port", PORT)
+    main()

--- a/starcheck/server.py
+++ b/starcheck/server.py
@@ -12,7 +12,7 @@ func_calls = collections.Counter()
 
 
 class PythonServer(socketserver.TCPServer):
-    timeout = 2
+    timeout = 180
 
     def handle_timeout(self) -> None:
         print(f"SERVER: starcheck python server timeout after {self.timeout}s idle",

--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -106,9 +106,6 @@ sub dither {
     # 2002262.094827395   | DSDITH  AODSDITH
     # 2002262.095427395   | ENDITH  AOENDITH
 
-    # Check that the dither history does not run into the load. This is the only thing
-    # that is checked for the dither history file, the values are not used.
-    # Starcheck v2.0: skip it?
     # Read the last 1000 bytes in the $dh_file (guaranteed to be enough).
     my $dith_hist_fh = IO::File->new($dh_file, "r") or croak "Can't open $dh_file: $!";
     $dith_hist_fh->seek(-1000, 2);
@@ -124,13 +121,12 @@ sub dither {
 
     if (not defined $dither_error){
         # If the most recent/last entry in the dither file has a timestamp newer than
-        # the first entry in the load, return string error and undef dither history.
+        # the first entry in the load, update the dither_error var.
         if ($dh_date ge $bs_arr->[0]->{date}){
             $dither_error = "Dither history runs into load\n";
         }
 
         # Confirm that last state matches kadi continuity ENAB/DISA.
-        # Otherwise, return string error and undef dither history.
         if ($kadi_dither->{'dither'} ne $dith_enab_cmd_map{$dh_state}){
             $dither_error = "Dither status in kadi commands does not match DITHER history\n"
               . sprintf("kadi '%s' ; History '%s' \n",

--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -128,7 +128,7 @@ sub dither {
 
         # Confirm that last state matches kadi continuity ENAB/DISA.
         if ($kadi_dither->{'dither'} ne $dith_enab_cmd_map{$dh_state}){
-            $dither_error = "Dither status in kadi commands does not match DITHER history\n"
+            $dither_error .= "Dither status in kadi commands does not match DITHER history\n"
               . sprintf("kadi '%s' ; History '%s' \n",
                         $kadi_dither->{'dither'},
                         $dith_enab_cmd_map{$dh_state});

--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -448,20 +448,26 @@ sub backstop {
     my $backstop = shift;
 
     my @bs = ();
+    my @dates = ();
     open (my $BACKSTOP, $backstop) || die "Couldn't open backstop file $backstop for reading\n";
     while (<$BACKSTOP>) {
-	my ($date, $vcdu, $cmd, $params) = split '\s*\|\s*', $_;
-	$vcdu =~ s/ +.*//; # Get rid of second field in vcdu
-	my %command = parse_params($params);
-	push @bs, { date => $date,
+    	my ($date, $vcdu, $cmd, $params) = split '\s*\|\s*', $_;
+    	$vcdu =~ s/ +.*//; # Get rid of second field in vcdu
+    	my %command = parse_params($params);
+    	push @bs, { date => $date,
 		    vcdu => $vcdu,
 		    cmd  => $cmd,
 		    params => $params,
-		    time => date2time($date),
 		    command => \%command,
 		};
+        push @dates, $date;
     }
     close $BACKSTOP;
+
+    my $times = date2time(\@dates);
+    for (my $i = 0; $i <= $#bs; $i++) {
+        $bs[$i]->{time} = $times->[$i];
+    }
 
     return @bs;
 }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -28,7 +28,6 @@ use File::Basename;
 use POSIX qw(floor);
 use English;
 use IO::All;
-use Data::Dumper qw(Dumper);
 
 use RDB;
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -145,18 +145,14 @@ sub set_ACA_bad_pixels {
     my @tmp = io($pixel_file)->slurp;
     my @lines = grep { /^\s+(\d|-)/ } @tmp;
     foreach (@lines) {
-	my @line = split /;|,/, $_;
-	foreach my $i ($line[0]..$line[1]) {
-	    foreach my $j ($line[2]..$line[3]) {
-		my $pixel = {'row' => $i,
+    	my @line = split /;|,/, $_;
+    	foreach my $i ($line[0]..$line[1]) {
+    	    foreach my $j ($line[2]..$line[3]) {
+                my $pixel = {'row' => $i,
                              'col' => $j};
-        my $call_vals = call_python("utils._pixels_to_yagzag", [$i, $j]);
-		my ($yag,$zag) = @$call_vals;
-		$pixel->{yag} = $yag;
-		$pixel->{zag} = $zag;
-		push @bad_pixels, $pixel;
-	    }
-	}
+                push @bad_pixels, $pixel;
+            }
+    	}
     }
 
     print STDERR "Read ", ($#bad_pixels+1), " ACA bad pixels from $pixel_file\n";
@@ -1445,8 +1441,8 @@ sub check_star_catalog {
         my @dr;
         if ($type =~ /GUI|BOT/){
 	    foreach my $pixel (@bad_pixels) {
-		my $dy = abs($yag-$pixel->{yag});
-		my $dz = abs($zag-$pixel->{zag});
+		my $dy = abs($pixel_row-$pixel->{row}) * 5;
+		my $dz = abs($pixel_col-$pixel->{col}) * 5;
 		my $dr = sqrt($dy**2 + $dz**2);
 		next unless ($dz < $self->{dither_guide}->{ampl_p} + 25 and $dy < $self->{dither_guide}->{ampl_y} + 25);
 		push @close_pixels, sprintf(" row, col (%d, %d), dy, dz (%d, %d) \n",

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1116,11 +1116,10 @@ sub check_star_catalog {
     }
 
     # Run the hot pixel region check on the Python side on FID|GUI|BOT
-    my $call_vals = call_python(
+    my @imposters = @{call_python(
         "utils.check_hot_pix",
         [\@idxs, \@yags, \@zags, \@mags, \@types,
-         $self->{ccd_temp}, $self->{date}, $dither_guide_y, $dither_guide_z]);
-    my @imposters = @$call_vals;
+         $self->{ccd_temp}, $self->{date}, $dither_guide_y, $dither_guide_z]);};
 
     # Assign warnings based on those hot pixel region checks
   IMPOSTER:
@@ -1284,8 +1283,7 @@ sub check_star_catalog {
 
 	# Star/fid outside of CCD boundaries
         # ACA-019 ACA-020 ACA-021
-    my $call_vals = call_python("utils._yagzag_to_pixels", [$yag, $zag]);
-	my ($pixel_row, $pixel_col) = @$call_vals;
+	my ($pixel_row, $pixel_col) = @{call_python("utils._yagzag_to_pixels", [$yag, $zag])};
 
         # Set "acq phase" dither to acq dither or 20.0 if undefined
         my $dither_acq_y = $self->{dither_acq}->{ampl_y} or 20.0;
@@ -2381,8 +2379,7 @@ sub star_image_map {
     # Convert all the yag/zags to pixel rows/cols
     my @yags = map { $self->{agasc_hash}->{$_}->{yag} } keys %plot_ids;
     my @zags = map { $self->{agasc_hash}->{$_}->{zag} } keys %plot_ids;
-    my $call_vals = call_python("utils._yagzag_to_pixels", [\@yags, \@zags]);
-    my ($pix_rows, $pix_cols) = @$call_vals;
+    my ($pix_rows, $pix_cols) = @{call_python("utils._yagzag_to_pixels", [\@yags, \@zags])};
 
 	my $map = "<map name=\"starmap_${obsid}\" id=\"starmap_${obsid}\"> \n";
     my @star_ids = keys %plot_ids;
@@ -2644,8 +2641,7 @@ sub set_proseco_probs_and_check_P2{
     if (not %{$args}){
         return;
     }
-    my $call_vals = call_python("utils.proseco_probs", [], $args);
-    my ($p_acqs, $P2, $expected) = @$call_vals;
+    my ($p_acqs, $P2, $expected) = @{call_python("utils.proseco_probs", [], $args)};
 
     $P2 = sprintf("%.1f", $P2);
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -20,12 +20,13 @@ package Ska::Starcheck::Obsid;
 
 use strict;
 use warnings;
+use Ska::Starcheck::Python qw(date2time time2date call_python);
 
 use Inline Python => q{
 import numpy as np
 from astropy.table import Table
 
-from starcheck.utils import time2date, date2time, de_bytestr
+from starcheck.utils import de_bytestr
 from mica.archive import aca_dark
 from chandra_aca.star_probs import guide_count
 from chandra_aca.transform import (yagzag_to_pixels, pixels_to_yagzag,

--- a/starcheck/src/lib/Ska/Starcheck/Python.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Python.pm
@@ -57,6 +57,8 @@ sub call_python {
     $handle->close();
 
     my $data = decode_json $response;
+    # print "CLIENT: Got response: $response\n";
+    # print Dumper($data);
     if (defined $data->{exception}) {
         my $msg = "\nPython exception:\n";
         $msg .= "command = " . Dumper($command) . "\n";
@@ -64,7 +66,6 @@ sub call_python {
         Carp::confess $msg;
     }
 
-    # print "CLIENT: Got result: $data->{result}\n";
     return $data->{result};
 }
 

--- a/starcheck/src/lib/Ska/Starcheck/Python.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Python.pm
@@ -12,16 +12,26 @@ require Exporter;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw();
-our @EXPORT_OK = qw(call_python date2time time2date);
+our @EXPORT_OK = qw(call_python date2time time2date set_port set_key);
 %EXPORT_TAGS = ( all => \@EXPORT_OK );
 
 STDOUT->autoflush(1);
 
 $Data::Dumper::Terse = 1;
 
-my $host = "localhost";
-my $port = 44123;
+my $HOST = "localhost";
+my $PORT = 40000;
+my $KEY = "fff";
 
+sub set_port {
+    $PORT = shift;
+    print "CLIENT: Setting port to $PORT\n";
+}
+
+sub set_key {
+    $KEY = shift;
+    print "CLIENT: Setting key to $KEY\n";
+}
 
 sub call_python {
     my $func = shift;
@@ -34,6 +44,7 @@ sub call_python {
         "func" => $func,
         "args" => $args,
         "kwargs" => $kwargs,
+        "key" => $KEY,
     };
     my $command_json = encode_json $command;
     # print "CLIENT: Sending command $command_json\n";
@@ -42,13 +53,13 @@ sub call_python {
     my $iter = 0;
     while ($iter++ < 10) {
         $handle = IO::Socket::INET->new(Proto     => "tcp",
-                                        PeerAddr  => $host,
-                                        PeerPort  => $port);
+                                        PeerAddr  => $HOST,
+                                        PeerPort  => $PORT);
         last if defined($handle);
         sleep 1;
     }
     if (!defined($handle)) {
-        die "Unable to connect to port $port on $host: $!";
+        die "Unable to connect to port $PORT on $HOST: $!";
     }
     $handle->autoflush(1);       # so output gets there right away
     $handle->write("$command_json\n");

--- a/starcheck/src/lib/Ska/Starcheck/Python.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Python.pm
@@ -1,0 +1,84 @@
+package Ska::Starcheck::Python;
+
+use strict;
+use warnings;
+use IO::Socket;
+use JSON;
+use Carp qw(confess);
+use Data::Dumper;
+
+use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
+require Exporter;
+
+our @ISA = qw(Exporter);
+our @EXPORT = qw();
+our @EXPORT_OK = qw(call_python date2time time2date);
+%EXPORT_TAGS = ( all => \@EXPORT_OK );
+
+STDOUT->autoflush(1);
+
+$Data::Dumper::Terse = 1;
+
+my $host = "localhost";
+my $port = 44123;
+
+
+sub call_python {
+    my $func = shift;
+    my $args = shift;
+    my $kwargs = shift;
+    if (!defined $args) { $args = []; }
+    if (!defined $kwargs) { $kwargs = {}; }
+
+    my $command = {
+        "func" => $func,
+        "args" => $args,
+        "kwargs" => $kwargs,
+    };
+    my $command_json = encode_json $command;
+    # print "CLIENT: Sending command $command_json\n";
+
+    my $handle;
+    my $iter = 0;
+    while ($iter++ < 10) {
+        $handle = IO::Socket::INET->new(Proto     => "tcp",
+                                        PeerAddr  => $host,
+                                        PeerPort  => $port);
+        last if defined($handle);
+        sleep 1;
+    }
+    if (!defined($handle)) {
+        die "Unable to connect to port $port on $host: $!";
+    }
+    $handle->autoflush(1);       # so output gets there right away
+    $handle->write("$command_json\n");
+
+    my $response = <$handle>;
+    $handle->close();
+
+    my $data = decode_json $response;
+    if (defined $data->{exception}) {
+        my $msg = "\nPython exception:\n";
+        $msg .= "command = " . Dumper($command) . "\n";
+        $msg .= "$data->{exception}\n";
+        Carp::confess $msg;
+    }
+
+    # print "CLIENT: Got result: $data->{result}\n";
+    return $data->{result};
+}
+
+
+sub date2time {
+    my $date = shift;
+    # print "date2time: $date\n";
+    return call_python("utils.date2time", [$date]);
+}
+
+
+sub time2date {
+    my $time = shift;
+    # print "time2date: $time\n";
+    return call_python("utils.time2date", [$time]);
+}
+

--- a/starcheck/src/lib/Ska/Starcheck/Python.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Python.pm
@@ -22,15 +22,18 @@ $Data::Dumper::Terse = 1;
 my $HOST = "localhost";
 my $PORT = 40000;
 my $KEY = "fff";
+my $VERBOSE = 1;
 
 sub set_port {
     $PORT = shift;
-    print "CLIENT: Setting port to $PORT\n";
 }
 
 sub set_key {
     $KEY = shift;
-    print "CLIENT: Setting key to $KEY\n";
+}
+
+sub set_debug {
+    $VERBOSE = shift;
 }
 
 sub call_python {
@@ -47,8 +50,10 @@ sub call_python {
         "key" => $KEY,
     };
     my $command_json = encode_json $command;
-    # print "CLIENT: Sending command $command_json\n";
 
+    if ($VERBOSE gt 2){
+	print STDERR "CLIENT: Sending command $command_json\n";
+    }
     my $handle;
     my $iter = 0;
     while ($iter++ < 10) {
@@ -68,8 +73,10 @@ sub call_python {
     $handle->close();
 
     my $data = decode_json $response;
-    # print "CLIENT: Got response: $response\n";
-    # print Dumper($data);
+    if ($VERBOSE gt 2){
+	print STDERR "CLIENT: Got response: $response\n";
+	print STDERR Dumper($data);
+    }
     if (defined $data->{exception}) {
         my $msg = "\nPython exception:\n";
         $msg .= "command = " . Dumper($command) . "\n";

--- a/starcheck/src/starcheck
+++ b/starcheck/src/starcheck
@@ -29,13 +29,7 @@ then
     exit 1
 fi
 
-PERL_INLINE_DIRECTORY=`mktemp -d -t starcheck_inline.XXXXXX` || exit 1
-export PERL_INLINE_DIRECTORY
 STARCHECK=`python -c 'import starcheck; print(starcheck.__path__[0])'`
 perl -I ${STARCHECK}/src/lib ${STARCHECK}/src/starcheck.pl "$@"
 SC_STATUS=$?
-if [[ -d $PERL_INLINE_DIRECTORY && $PERL_INLINE_DIRECTORY =~ .*starcheck_inline.* ]];
-then
-    rm -r $PERL_INLINE_DIRECTORY
-fi
 exit $SC_STATUS

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -119,7 +119,7 @@ my $font_stop = qq{</font>};
 # kadi log levels are a little different and INFO (corresponding to the default
 # verbose=1) is too chatty for the default. Instead allow only verbose=0
 # (CRITICAL) or verbose=2 (DEBUG).
-my $kadi_verbose = $par{verbose} eq '2' ? '2' : '0';
+my $kadi_verbose = $par{verbose} gt 1 ? '2' : '0';
 call_python("utils.config_logging", [$STARCHECK, $kadi_verbose, "kadi"]);
 call_python("utils.set_kadi_scenario_default");
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -72,6 +72,9 @@ GetOptions( \%par,
     ) ||
     exit( 1 );
 
+usage( 1 )
+    if $par{help};
+
 
 my $sock = IO::Socket::INET->new(
     LocalAddr => '', LocalPort => 0, Proto => 'tcp', Listen => 1);
@@ -110,8 +113,6 @@ my $yellow_font_start = qq{<font color="#009900">};
 my $blue_font_start = qq{<font color="#0000FF">};
 my $font_stop = qq{</font>};
 
-usage( 1 )
-    if $par{help};
 
 # kadi log levels are a little different and INFO (corresponding to the default
 # verbose=1) is too chatty for the default. Instead allow only verbose=0

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -1209,6 +1209,12 @@ Default is '.'.
 Output reports will be <out>.html, <out>.txt.  Star plots will be
 <out>/stars_<obsid>.png.  The default is <out> = 'STARCHECK'.
 
+=item B<-verbose <level>>
+
+Output verbosity. The default is 1. verbose=2 includes kadi logger INFO statements,
+starcheck.server startup and shutdown information. verbose > 2 includes starcheck.server
+full debug output.
+
 =item B<-vehicle>
 
 Use vehicle-only products and the vehicle-only ACA checklist to perform

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -91,13 +91,19 @@ my $server_key = join '', map +(0..9,'a'..'z','A'..'Z')[rand 62], 1..16;
 # Configure the Python interface
 Ska::Starcheck::Python::set_port($server_port);
 Ska::Starcheck::Python::set_key($server_key);
+Ska::Starcheck::Python::set_debug($par{verbose});
+if ($par{verbose} gt 1){
+    print STDERR "CLIENT: starcheck.server started on port $server_port\n";
+    print STDERR "CLIENT: starcheck.server key $server_key\n";
+}
 
 # Start a server that can call functions in the starcheck package
 my $pid = open(SERVER, "| python -m starcheck.server");
 SERVER->autoflush(1);
-# Send the port and key to the server
+# Send the port, key, and verbosity to the server
 print SERVER "$server_port\n";
 print SERVER "$server_key\n";
+print SERVER "$par{verbose}\n";
 
 # DEBUG, limit number of obsids.
 # Set to undef for no limit (though option defaults to 0)
@@ -1167,8 +1173,10 @@ END {
 	    print("Python server calls:");
 	    print Dumper($server_calls);
 	}
-        print("Shutting down python starcheck server with pid=$pid\n");
-        kill 9, $pid;                    # must it be 9 (SIGKILL)?
+	if ($par{verbose} gt 1){
+	    print("Shutting down python starcheck server with pid=$pid\n");
+	}
+	kill 9, $pid;                    # must it be 9 (SIGKILL)?
         my $gone_pid = waitpid $pid, 0;  # then check that it's gone
     }
 };

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -106,11 +106,8 @@ GetOptions( \%par,
     ) ||
     exit( 1 );
 
-
 my $Starcheck_Data = $par{sc_data} || call_python("utils.get_data_dir");
 my $STARCHECK   = $par{out} || ($par{vehicle} ? 'v_starcheck' : 'starcheck');
-
-
 
 my $empty_font_start = qq{<font>};
 my $red_font_start = qq{<font color="#FF0000">};
@@ -1164,6 +1161,10 @@ sub usage
 
 END {
     if (defined $pid) {
+        my $server_calls = call_python("get_server_calls");
+        # print the server_calls hash sorted by value in descending order
+        print("Python server calls:");
+        print Dump($server_calls);
         print("Killing python server with pid=$pid\n");
         kill 9, $pid;                    # must it be 9 (SIGKILL)?
         my $gone_pid = waitpid $pid, 0;  # then check that it's gone

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -43,10 +43,9 @@ if ($pid = fork) {} else {
   exec('python', '-m', 'starcheck.server');
 }
 
-
-print "Starting starcheck.pl\n";
-print call_python("utils.time2date", [150000000.]) . "\n";
-print time2date(300000000.) . "\n";
+# DEBUG, limit number of obsids. TODO make this a command line option.
+# Set to undef for no limit.
+my $MAX_OBSIDS = 8;
 
 my $version = call_python("utils.starcheck_version");
 
@@ -362,7 +361,7 @@ for my $i (0 .. $#cmd) {
 				 time => $time[$i],
 				 cmd  => $cmd[$i] } );
 
-    if ($n_obsid > 4) {
+    if (defined $MAX_OBSIDS and $n_obsid > $MAX_OBSIDS) {
         last;
     }
 }

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -50,6 +50,7 @@ my %par = (dir  => '.',
 		   fid_char => "fid_CHARACTERISTICS",
            verbose => 1,
 	   maude => 0,
+	   max_obsids => 0,
     );
 
 
@@ -69,6 +70,7 @@ GetOptions( \%par,
 			'config_file=s',
                         'run_start_time=s',
 	    'maude!',
+	    'max_obsids:i',
     ) ||
     exit( 1 );
 
@@ -96,9 +98,9 @@ SERVER->autoflush(1);
 print SERVER "$server_port\n";
 print SERVER "$server_key\n";
 
-# DEBUG, limit number of obsids. TODO make this a command line option.
-# Set to undef for no limit.
-my $MAX_OBSIDS = undef;
+# DEBUG, limit number of obsids.
+# Set to undef for no limit (though option defaults to 0)
+my $MAX_OBSIDS = $par{max_obsids} > 0 ? $par{max_obsids} : undef;
 
 my $version = call_python("utils.starcheck_version");
 
@@ -414,10 +416,12 @@ foreach my $obsid (@obsid_id) {
 }
 
 # Check that every Guide summary OFLS ID has a matching OFLS ID in DOT
-
-foreach my $oflsid (keys %guidesumm){
-    unless (defined $obs{$oflsid}){
-     #warning("OFLS ID $oflsid in Guide Summ but not in DOT! \n");
+# Skip this check if developing code with MAX_OBSIDS set
+if (not defined $MAX_OBSIDS){
+    foreach my $oflsid (keys %guidesumm){
+	unless (defined $obs{$oflsid}){
+	    warning("OFLS ID $oflsid in Guide Summ but not in DOT! \n");
+	}
     }
 }
 
@@ -1219,6 +1223,10 @@ Enable (or disable) generation of report in TEXT format.  Default is TEXT enable
 
 Use MAUDE for telemetry instead of default cheta cxc archive.
 MAUDE will also be used if no AACCCDPT telemetry can be found in cheta archive for initial conditions.
+
+=item B<-max_obsids <N>>
+
+Limit starcheck review to first N obsids (for testing).
 
 =item B<-agasc_file <agasc>>
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -12,6 +12,7 @@
 
 use strict;
 use warnings;
+use Data::Dumper;
 use Getopt::Long;
 use IO::File;
 use IO::All;
@@ -1164,7 +1165,7 @@ END {
 	    my $server_calls = call_python("get_server_calls");
 	    # print the server_calls hash sorted by value in descending order
 	    print("Python server calls:");
-	    print Dump($server_calls);
+	    print Dumper($server_calls);
 	}
         print("Shutting down python starcheck server with pid=$pid\n");
         kill 9, $pid;                    # must it be 9 (SIGKILL)?

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -440,8 +440,7 @@ foreach my $oflsid (@obsid_id){
 		$obs{$oflsid}->add_guide_summ($oflsid, \%guidesumm);
     }
     else {
-	my $obsid = $obs{$oflsid}->{obsid};
-	my $cat = Ska::Starcheck::Obsid::find_command($obs{$obsid}, "MP_STARCAT");
+	my $cat = Ska::Starcheck::Obsid::find_command($obs{$oflsid}, "MP_STARCAT");
 	if (defined $cat){
 	    push @{$obs{$oflsid}->{warn}}, sprintf("No Guide Star Summary for obsid $obsid ($oflsid). \n");
 	}

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -1155,11 +1155,13 @@ sub usage
 
 END {
     if (defined $pid) {
-        my $server_calls = call_python("get_server_calls");
-        # print the server_calls hash sorted by value in descending order
-        print("Python server calls:");
-        print Dump($server_calls);
-        print("Killing python server with pid=$pid\n");
+	if ($par{verbose} gt 1){
+	    my $server_calls = call_python("get_server_calls");
+	    # print the server_calls hash sorted by value in descending order
+	    print("Python server calls:");
+	    print Dump($server_calls);
+	}
+        print("Shutting down python starcheck server with pid=$pid\n");
         kill 9, $pid;                    # must it be 9 (SIGKILL)?
         my $gone_pid = waitpid $pid, 0;  # then check that it's gone
     }

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -50,20 +50,13 @@ my $server_key = join '', map +(0..9,'a'..'z','A'..'Z')[rand 62], 1..16;
 Ska::Starcheck::Python::set_port($server_port);
 Ska::Starcheck::Python::set_key($server_key);
 
-# Global process ID for fork that gets set in the parent process. This is
-# used to kill the forked process when the parent finishes.
-my $pid;
-
 # Start a server that can call functions in the starcheck package
-if ($pid = fork) {} else {
-    open(SERVER, "| python -m starcheck.server");
-    SERVER->autoflush(1);
-    # Send the port and key to the server
-    print SERVER "$server_port\n";
-    print SERVER "$server_key\n";
-    # Forked process waits until it gets killed by the parent finishing
-    sleep;
-}
+print "Here in the forked process\n";
+my $pid = open(SERVER, "| python -m starcheck.server");
+SERVER->autoflush(1);
+# Send the port and key to the server
+print SERVER "$server_port\n";
+print SERVER "$server_key\n";
 
 # DEBUG, limit number of obsids. TODO make this a command line option.
 # Set to undef for no limit.

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -67,7 +67,7 @@ if ($pid = fork) {} else {
 
 # DEBUG, limit number of obsids. TODO make this a command line option.
 # Set to undef for no limit.
-my $MAX_OBSIDS = 8;
+my $MAX_OBSIDS = undef;
 
 my $version = call_python("utils.starcheck_version");
 

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import proseco.characteristics as proseco_char
 from Chandra.Time import DateTime
-from Chandra.Time import date2secs, secs2date
+import cxotime
 from kadi.commands import states
 from testr import test_helper
 
@@ -16,6 +16,36 @@ from starcheck.calc_ccd_temps import get_ccd_temps
 from starcheck.check_ir_zone import ir_zone_ok
 from starcheck.pcad_att_check import make_pcad_attitude_check_report
 from starcheck.plot import make_plots_for_obsid
+
+
+def date2secs(val):
+    """Convert date to seconds since 1998.0"""
+    out = cxotime.date2secs(val)
+    # if isinstance(out, (np.number, np.ndarray)):
+    #     out = out.tolist()
+    return out
+
+
+def secs2date(val):
+    """Convert date to seconds since 1998.0"""
+    out = cxotime.secs2date(val)
+    # if isinstance(out, (np.number, np.ndarray)):
+    #    out = out.tolist()
+    return out
+
+
+def date2time(val):
+    out = cxotime.date2secs(val)
+    if isinstance(out, (np.number, np.ndarray)):
+        out = out.tolist()
+    return out
+
+
+def time2date(val):
+    out = cxotime.secs2date(val)
+    if isinstance(out, (np.number, np.ndarray)):
+        out = out.tolist()
+    return out
 
 
 def python_from_perl(func):
@@ -50,10 +80,6 @@ def de_bytestr(data):
     if isinstance(data, set):
         return set(map(de_bytestr, data))
     return data
-
-
-date2time = python_from_perl(date2secs)
-time2date = python_from_perl(secs2date)
 
 
 @python_from_perl

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -3,10 +3,10 @@ import logging
 import os
 from pathlib import Path
 
+import cxotime
 import numpy as np
 import proseco.characteristics as proseco_char
 from Chandra.Time import DateTime
-import cxotime
 from kadi.commands import states
 from testr import test_helper
 
@@ -54,6 +54,7 @@ def python_from_perl(func):
     - Convert byte strings to unicode.
     - Print stack trace on exceptions which perl inline suppresses.
     """
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         args = de_bytestr(args)
@@ -62,8 +63,10 @@ def python_from_perl(func):
             return func(*args, **kwargs)
         except Exception:
             import traceback
+
             traceback.print_exc()
             raise
+
     return wrapper
 
 
@@ -108,26 +111,26 @@ def set_kadi_scenario_default():
     # This is aimed at running in production where the commands archive is
     # updated hourly. In this case no network resources are used.
     if test_helper.on_head_network():
-        os.environ.setdefault('KADI_SCENARIO', 'flight')
+        os.environ.setdefault("KADI_SCENARIO", "flight")
 
 
 @python_from_perl
 def get_cheta_source():
     sources = starcheck.calc_ccd_temps.fetch.data_source.sources()
-    if len(sources) == 1 and sources[0] == 'cxc':
-        return 'cxc'
+    if len(sources) == 1 and sources[0] == "cxc":
+        return "cxc"
     else:
         return str(sources)
 
 
 @python_from_perl
 def get_kadi_scenario():
-    return os.getenv('KADI_SCENARIO', default="None")
+    return os.getenv("KADI_SCENARIO", default="None")
 
 
 @python_from_perl
 def get_data_dir():
-    sc_data = os.path.join(os.path.dirname(starcheck.__file__), 'data')
+    sc_data = os.path.join(os.path.dirname(starcheck.__file__), "data")
     return sc_data if os.path.exists(sc_data) else ""
 
 
@@ -143,15 +146,26 @@ def make_ir_check_report(kwargs):
 
 @python_from_perl
 def get_dither_kadi_state(date):
-    cols = ['dither', 'dither_ampl_pitch', 'dither_ampl_yaw',
-            'dither_period_pitch', 'dither_period_yaw']
+    cols = [
+        "dither",
+        "dither_ampl_pitch",
+        "dither_ampl_yaw",
+        "dither_period_pitch",
+        "dither_period_yaw",
+    ]
     state = states.get_continuity(date, cols)
     # Cast the numpy floats as plain floats
-    for key in ['dither_ampl_pitch', 'dither_ampl_yaw',
-                'dither_period_pitch', 'dither_period_yaw']:
+    for key in [
+        "dither_ampl_pitch",
+        "dither_ampl_yaw",
+        "dither_period_pitch",
+        "dither_period_yaw",
+    ]:
         state[key] = float(state[key])
     # get most recent change time
-    state['time'] = float(np.max([DateTime(state['__dates__'][key]).secs for key in cols]))
+    state["time"] = float(
+        np.max([DateTime(state["__dates__"][key]).secs for key in cols])
+    )
     return state
 
 
@@ -204,12 +218,13 @@ def config_logging(outdir, verbose, name):
     class NullHandler(logging.Handler):
         def emit(self, record):
             pass
+
     rootlogger = logging.getLogger()
     rootlogger.addHandler(NullHandler())
 
-    loglevel = {0: logging.CRITICAL,
-                1: logging.INFO,
-                2: logging.DEBUG}.get(int(verbose), logging.INFO)
+    loglevel = {0: logging.CRITICAL, 1: logging.INFO, 2: logging.DEBUG}.get(
+        int(verbose), logging.INFO
+    )
 
     logger = logging.getLogger(name)
     logger.setLevel(loglevel)
@@ -218,7 +233,7 @@ def config_logging(outdir, verbose, name):
     for handler in list(logger.handlers):
         logger.removeHandler(handler)
 
-    formatter = logging.Formatter('%(message)s')
+    formatter = logging.Formatter("%(message)s")
 
     console = logging.StreamHandler()
     console.setFormatter(formatter)
@@ -226,6 +241,6 @@ def config_logging(outdir, verbose, name):
 
     outdir = Path(outdir)
     outdir.mkdir(parents=True, exist_ok=True)
-    filehandler = logging.FileHandler(filename=outdir / 'run.dat', mode='w')
+    filehandler = logging.FileHandler(filename=outdir / "run.dat", mode="w")
     filehandler.setFormatter(formatter)
     logger.addHandler(filehandler)

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -226,7 +226,8 @@ def _pixels_to_yagzag(i, j):
     :returns tuple: yag, zag as floats
     """
     yag, zag = pixels_to_yagzag(i, j, allow_bad=True)
-    return float(yag), float(zag)
+    # Convert to lists or floats to avoid numpy types which are not JSON serializable
+    return yag.tolist(), zag.tolist()
 
 
 def _yagzag_to_pixels(yag, zag):
@@ -240,7 +241,8 @@ def _yagzag_to_pixels(yag, zag):
     :returns tuple: row, col as floats
     """
     row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
-    return float(row), float(col)
+    # Convert to lists or floats to avoid numpy types which are not JSON serializable
+    return row.tolist(), col.tolist()
 
 
 def _guide_count(mags, t_ccd, count_9th=False):

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -432,7 +432,7 @@ def proseco_probs(**kw):
     a specific obsid catalog and return the individual acq star probabilities,
     the P2 value for the catalog, and the expected number of acq stars.
 
-    `kwargs` will be a Perl hash converted to dict (by Inline) of the expected
+    `kwargs` will be a Perl hash converted to dict of the expected
     keyword params. These keys must be defined:
 
     'q1', 'q2', 'q3', 'q4' = the target quaternion 'man_angle' the maneuver

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -1,13 +1,25 @@
-import functools
 import logging
 import os
 from pathlib import Path
 
+import agasc
 import cxotime
+import mica.stats.acq_stats
+import mica.stats.guide_stats
 import numpy as np
 import proseco.characteristics as proseco_char
+import proseco.characteristics as char
+import Quaternion
+from astropy.table import Table
 from Chandra.Time import DateTime
+from chandra_aca.star_probs import guide_count, mag_for_p_acq
+from chandra_aca.transform import mag_to_count_rate, pixels_to_yagzag, yagzag_to_pixels
 from kadi.commands import states
+from mica.archive import aca_dark
+from proseco.catalog import get_aca_catalog, get_effective_t_ccd
+from proseco.core import ACABox
+from proseco.guide import get_imposter_mags
+from Ska.quatutil import radec2yagzag
 from testr import test_helper
 
 import starcheck
@@ -16,6 +28,9 @@ from starcheck.calc_ccd_temps import get_ccd_temps
 from starcheck.check_ir_zone import ir_zone_ok
 from starcheck.pcad_att_check import make_pcad_attitude_check_report
 from starcheck.plot import make_plots_for_obsid
+
+ACQS = mica.stats.acq_stats.get_stats()
+GUIDES = mica.stats.guide_stats.get_stats()
 
 
 def date2secs(val):
@@ -48,64 +63,22 @@ def time2date(val):
     return out
 
 
-def python_from_perl(func):
-    """Decorator to facilitate calling Python from Perl inline.
-
-    - Convert byte strings to unicode.
-    - Print stack trace on exceptions which perl inline suppresses.
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        args = de_bytestr(args)
-        kwargs = de_bytestr(kwargs)
-        try:
-            return func(*args, **kwargs)
-        except Exception:
-            import traceback
-
-            traceback.print_exc()
-            raise
-
-    return wrapper
-
-
-# Borrowed from https://stackoverflow.com/a/33160507
-def de_bytestr(data):
-    if isinstance(data, bytes):
-        return data.decode()
-    if isinstance(data, dict):
-        return dict(map(de_bytestr, data.items()))
-    if isinstance(data, tuple):
-        return tuple(map(de_bytestr, data))
-    if isinstance(data, list):
-        return list(map(de_bytestr, data))
-    if isinstance(data, set):
-        return set(map(de_bytestr, data))
-    return data
-
-
-@python_from_perl
-def ccd_temp_wrapper(kwargs):
+def ccd_temp_wrapper(**kwargs):
     return get_ccd_temps(**kwargs)
 
 
-@python_from_perl
-def plot_cat_wrapper(kwargs):
+def plot_cat_wrapper(**kwargs):
     return make_plots_for_obsid(**kwargs)
 
 
-@python_from_perl
 def starcheck_version():
     return version
 
 
-@python_from_perl
 def get_chandra_models_version():
     return proseco_char.chandra_models_version
 
 
-@python_from_perl
 def set_kadi_scenario_default():
     # For kadi commands v2 running on HEAD set the default scenario to flight.
     # This is aimed at running in production where the commands archive is
@@ -114,7 +87,6 @@ def set_kadi_scenario_default():
         os.environ.setdefault("KADI_SCENARIO", "flight")
 
 
-@python_from_perl
 def get_cheta_source():
     sources = starcheck.calc_ccd_temps.fetch.data_source.sources()
     if len(sources) == 1 and sources[0] == "cxc":
@@ -123,28 +95,23 @@ def get_cheta_source():
         return str(sources)
 
 
-@python_from_perl
 def get_kadi_scenario():
     return os.getenv("KADI_SCENARIO", default="None")
 
 
-@python_from_perl
 def get_data_dir():
     sc_data = os.path.join(os.path.dirname(starcheck.__file__), "data")
     return sc_data if os.path.exists(sc_data) else ""
 
 
-@python_from_perl
-def _make_pcad_attitude_check_report(kwargs):
+def _make_pcad_attitude_check_report(**kwargs):
     return make_pcad_attitude_check_report(**kwargs)
 
 
-@python_from_perl
-def make_ir_check_report(kwargs):
+def make_ir_check_report(**kwargs):
     return ir_zone_ok(**kwargs)
 
 
-@python_from_perl
 def get_dither_kadi_state(date):
     cols = [
         "dither",
@@ -169,7 +136,6 @@ def get_dither_kadi_state(date):
     return state
 
 
-@python_from_perl
 def get_run_start_time(run_start_time, backstop_start):
     """
     Determine a reasonable reference run start time based on the supplied
@@ -206,7 +172,6 @@ def get_run_start_time(run_start_time, backstop_start):
     return ref_time.date
 
 
-@python_from_perl
 def config_logging(outdir, verbose, name):
     """Set up file and console logger.
     See http://docs.python.org/library/logging.html
@@ -244,3 +209,272 @@ def config_logging(outdir, verbose, name):
     filehandler = logging.FileHandler(filename=outdir / "run.dat", mode="w")
     filehandler.setFormatter(formatter)
     logger.addHandler(filehandler)
+
+
+def _get_aca_limits():
+    return float(char.aca_t_ccd_planning_limit), float(char.aca_t_ccd_penalty_limit)
+
+
+def _pixels_to_yagzag(i, j):
+    """
+    Call chandra_aca.transform.pixels_to_yagzag.
+    This wrapper is set to pass allow_bad=True, as exceptions from the Python side
+    in this case would not be helpful, and the very small bad pixel list should be
+    on the CCD.
+    :params i: pixel row
+    :params j: pixel col
+    :returns tuple: yag, zag as floats
+    """
+    yag, zag = pixels_to_yagzag(i, j, allow_bad=True)
+    return float(yag), float(zag)
+
+
+def _yagzag_to_pixels(yag, zag):
+    """
+    Call chandra_aca.transform.yagzag_to_pixels.
+    This wrapper is set to pass allow_bad=True, as exceptions from the Python side
+    in this case would not be helpful, and the boundary checks and such will work fine
+    on the Perl side even if the returned row/col is off the CCD.
+    :params yag: y-angle arcsecs (hopefully as a number from the Perl)
+    :params zag: z-angle arcsecs (hopefully as a number from the Perl)
+    :returns tuple: row, col as floats
+    """
+    row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
+    return float(row), float(col)
+
+
+def _guide_count(mags, t_ccd, count_9th=False):
+    eff_t_ccd = get_effective_t_ccd(t_ccd)
+    return float(guide_count(np.array(mags), eff_t_ccd, count_9th))
+
+
+def check_hot_pix(idxs, yags, zags, mags, types, t_ccd, date, dither_y, dither_z):
+    """
+    Return a list of info to make warnings on guide stars or fid lights with
+    local dark map that gives an 'imposter_mag' that could perturb a centroid.
+    The potential worst-case offsets (ignoring effects at the background pixels)
+    are returned and checking against offset limits needs to be done from
+    calling code.
+
+    This fetches the dark current before the date of the observation and passes
+    it to proseco.get_imposter_mags with the star candidate positions to fetch
+    the brightest 2x2 for each and calculates the mag for that region.  The
+    worse case offset is then added to an entry for the star index.
+
+    :param idxs: catalog indexes as list or array
+    :param yags: catalog yangs as list or array
+    :param zags: catalog zangs as list or array
+    :param mags: catalog mags (AGASC mags for stars estimated fid mags for fids)
+        list or array
+    :param types: catalog TYPE (ACQ|BOT|FID|MON|GUI) as list or array
+    :param t_ccd: observation t_ccd in deg C (should be max t_ccd in guide
+        phase)
+    :param date: observation date (str)
+    :param dither_y: dither_y in arcsecs (guide dither)
+    :param dither_z: dither_z in arcsecs (guide dither)
+    :param yellow_lim: yellow limit centroid offset threshold limit (in arcsecs)
+    :param red_lim: red limit centroid offset threshold limit (in arcsecs)
+    :return imposters: list of dictionaries with keys that define the index, the
+             imposter mag, a 'status' key that has value 0 if the code to get
+             the imposter mag ran successfully, calculated centroid offset, and
+             star or fid info to make a warning.
+    """
+
+    eff_t_ccd = get_effective_t_ccd(t_ccd)
+
+    dark = aca_dark.get_dark_cal_image(date=date, t_ccd_ref=eff_t_ccd, aca_image=True)
+
+    def imposter_offset(cand_mag, imposter_mag):
+        """
+        For a given candidate star and the pseudomagnitude of the brightest 2x2
+        imposter calculate the max offset of the imposter counts are at the edge
+        of the 6x6 (as if they were in one pixel).  This is somewhat the inverse
+        of proseco.get_pixmag_for_offset
+        """
+        cand_counts = mag_to_count_rate(cand_mag)
+        spoil_counts = mag_to_count_rate(imposter_mag)
+        return spoil_counts * 3 * 5 / (spoil_counts + cand_counts)
+
+    imposters = []
+    for idx, yag, zag, mag, ctype in zip(idxs, yags, zags, mags, types):
+        if ctype in ["BOT", "GUI", "FID"]:
+            if ctype in ["BOT", "GUI"]:
+                dither = ACABox((dither_y, dither_z))
+            else:
+                dither = ACABox((5.0, 5.0))
+            row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
+            # Handle any errors in get_imposter_mags with a try/except.  This doesn't
+            # try to pass back a message.  Most likely this will only fail if the star
+            # or fid is completely off the CCD and will have other warning.
+            try:
+                # get_imposter_mags takes a Table of candidates as its first argument, so construct
+                # a single-candidate table `entries`
+                entries = Table(
+                    [{"idx": idx, "row": row, "col": col, "mag": mag, "type": ctype}]
+                )
+                imp_mags, imp_rows, imp_cols = get_imposter_mags(entries, dark, dither)
+                offset = imposter_offset(mag, imp_mags[0])
+                imposters.append(
+                    {
+                        "idx": int(idx),
+                        "status": int(0),
+                        "entry_row": float(row),
+                        "entry_col": float(col),
+                        "bad2_row": float(imp_rows[0]),
+                        "bad2_col": float(imp_cols[0]),
+                        "bad2_mag": float(imp_mags[0]),
+                        "offset": float(offset),
+                    }
+                )
+            except Exception:
+                imposters.append({"idx": int(idx), "status": int(1)})
+    return imposters
+
+
+def _get_agasc_stars(ra, dec, roll, radius, date, agasc_file):
+    """
+    Fetch the cone of agasc stars.  Update the table with the yag and zag of each star.
+    Return as a dictionary with the agasc ids as keys and all of the values as
+    simple Python types (int, float)
+    """
+    stars = agasc.get_agasc_cone(
+        float(ra),
+        float(dec),
+        float(radius),
+        date,
+        agasc_file,
+    )
+    q_aca = Quaternion.Quat([float(ra), float(dec), float(roll)])
+    yags, zags = radec2yagzag(stars["RA_PMCORR"], stars["DEC_PMCORR"], q_aca)
+    yags *= 3600
+    zags *= 3600
+    stars["yang"] = yags
+    stars["zang"] = zags
+
+    # Get a dictionary of the stars with the columns that are used
+    # This needs to be de-numpy-ified to pass back into Perl
+    stars_dict = {}
+    for star in stars:
+        stars_dict[str(star["AGASC_ID"])] = {
+            "id": int(star["AGASC_ID"]),
+            "class": int(star["CLASS"]),
+            "ra": float(star["RA_PMCORR"]),
+            "dec": float(star["DEC_PMCORR"]),
+            "mag_aca": float(star["MAG_ACA"]),
+            "bv": float(star["COLOR1"]),
+            "color1": float(star["COLOR1"]),
+            "mag_aca_err": float(star["MAG_ACA_ERR"]),
+            "poserr": float(star["POS_ERR"]),
+            "yag": float(star["yang"]),
+            "zag": float(star["zang"]),
+            "aspq": int(star["ASPQ1"]),
+            "var": int(star["VAR"]),
+            "aspq1": int(star["ASPQ1"]),
+        }
+
+    return stars_dict
+
+
+def get_mica_star_stats(agasc_id, time):
+    """
+    Get the acq and guide star statistics for a star before a given time.
+    The time filter is just there to make this play well when run in regression.
+    The mica acq and guide stats are fetched into globals ACQS and GUIDES
+    and this method just filters for the relevant ones for a star and returns
+    a dictionary of summarized statistics.
+
+    :param agasc_id: agasc id of star
+    :param time: time used as end of range to retrieve statistics.
+
+    :return: dictionary of stats for the observed history of the star
+    """
+
+    # Cast the inputs
+    time = float(time)
+    agasc_id = int(agasc_id)
+
+    acqs = Table(ACQS[(ACQS["agasc_id"] == agasc_id) & (ACQS["guide_tstart"] < time)])
+    ok = acqs["img_func"] == "star"
+    guides = Table(
+        GUIDES[(GUIDES["agasc_id"] == agasc_id) & (GUIDES["kalman_tstart"] < time)]
+    )
+    mags = np.concatenate(
+        [
+            acqs["mag_obs"][acqs["mag_obs"] != 0],
+            guides["aoacmag_mean"][guides["aoacmag_mean"] != 0],
+        ]
+    )
+
+    avg_mag = float(np.mean(mags)) if (len(mags) > 0) else float(13.94)
+    stats = {
+        "acq": len(acqs),
+        "acq_noid": int(np.count_nonzero(~ok)),
+        "gui": len(guides),
+        "gui_bad": int(np.count_nonzero(guides["f_track"] < 0.95)),
+        "gui_fail": int(np.count_nonzero(guides["f_track"] < 0.01)),
+        "gui_obc_bad": int(np.count_nonzero(guides["f_obc_bad"] > 0.05)),
+        "avg_mag": avg_mag,
+    }
+    return stats
+
+
+def _mag_for_p_acq(p_acq, date, t_ccd):
+    """
+    Call mag_for_p_acq, but cast p_acq and t_ccd as floats.
+    """
+    eff_t_ccd = get_effective_t_ccd(t_ccd)
+    return mag_for_p_acq(float(p_acq), date, float(eff_t_ccd))
+
+
+def proseco_probs(**kw):
+    """
+    Call proseco's get_acq_catalog with the parameters supplied in `kwargs` for
+    a specific obsid catalog and return the individual acq star probabilities,
+    the P2 value for the catalog, and the expected number of acq stars.
+
+    `kwargs` will be a Perl hash converted to dict (by Inline) of the expected
+    keyword params. These keys must be defined:
+
+    'q1', 'q2', 'q3', 'q4' = the target quaternion 'man_angle' the maneuver
+    angle to the target quaternion in degrees. 'acq_ids' list of acq star ids
+    'halfwidths' list of acq star halfwidths in arcsecs 't_ccd_acq' acquisition
+    temperature in deg C 'date' observation date (in Chandra.Time compatible
+    format) 'detector' science detector 'sim_offset' SIM offset
+
+    As these values are from a Perl hash, bytestrings will be converted by
+    de_bytestr early in this method.
+
+    :param **kw: dict of expected keywords
+    :return tuple: (list of floats of star acq probabilties, float P2, float
+        expected acq stars)
+
+    """
+
+    args = dict(
+        obsid=0,
+        att=Quaternion.normalize(kw["att"]),
+        date=kw["date"],
+        n_acq=kw["n_acq"],
+        man_angle=kw["man_angle"],
+        t_ccd_acq=kw["t_ccd_acq"],
+        t_ccd_guide=kw["t_ccd_guide"],
+        dither_acq=ACABox(kw["dither_acq"]),
+        dither_guide=ACABox(kw["dither_guide"]),
+        include_ids_acq=kw["include_ids_acq"],
+        include_halfws_acq=kw["include_halfws_acq"],
+        detector=kw["detector"],
+        sim_offset=kw["sim_offset"],
+        n_fid=0,
+        n_guide=0,
+        focus_offset=0,
+    )
+    aca = get_aca_catalog(**args)
+    acq_cat = aca.acqs
+
+    # Assign the proseco probabilities back into an array.
+    p_acqs = [
+        float(acq_cat["p_acq"][acq_cat["id"] == acq_id][0])
+        for acq_id in kw["include_ids_acq"]
+    ]
+
+    return p_acqs, float(-np.log10(acq_cat.calc_p_safe())), float(np.sum(p_acqs))


### PR DESCRIPTION
## Description

Driven by problems getting `Inline::Python` to work with ska3-prime, this PR replaces all the inline Python calls with a call to a new lightweight server process that runs Python function calls. This is basically the idea that @javierggt for an API server, but it users an even lighter framework (than e.g. flask) for performance. The server gets called at least thousands of times currently, though there are probably opportunities to reduce that with some code changes.

Current testing status is that it runs to completion on the DEC1922 loads and produces output that looks about right. 

Process management for the Python function server (`starcheck/server.py`) took a little time to work out but it seems to be working, more or less. There might still be room for improvement.

The new server includes reasonable exception handling.

To do:
- [x] Proper logging not print statements
- [x] Improve performance
- [x] Get a free port from the system in Perl then pass that to the Python server
- [x] Secure communications by using a random key that is shared between client and server
- [x] Improve the `get_fid_actions` sub in parse CM. I think this might be broken for running loads in the far past.
- [x] Testing

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
#### Output comparison
Ran starcheck for DEC1922A loads in this branch and in master:
```
$ ./sandbox_starcheck -dir $SKA/data/mpcrit1/mplogs/2022/DEC1922/oflsa -run_start_time=2022:352:00:00:00 -out out_{pyserver,master}
```
Then:
```
ska3) ➜  starcheck git:(no-inline-python) diff out_pyserver.txt out_master.txt
1,2c1,2
<  ------------  Starcheck 13.17.1.dev21+gd6087bd.d20230101    -----------------
<  Run on Sun Jan  1 06:45:26 EST 2023 by aldcroft from daze
---
>  ------------  Starcheck 13.17.1.dev9+g6057b15    -----------------
>  Run on Sat Dec 31 10:35:06 EST 2022 by aldcroft from daze
```

On ska3-flight HEAD linux

- [x] Confirmed that ctrl-c of the sandbox starcheck script results in all perl and python processes going away.
- [x] kill -9 of a the calling perl did not kill the starcheck.server python but it times out appropriately
- [x] Did a functional test with dither manually set to run into the load and not match kadi - completed successfully with only kadi initial state used for propagation and two warning recorded in starcheck.txt
- [x] confirmed -help works
- [x] confirmed -verbose 2 3 show different levels of outputs
- [x] confirmed -max_obsids stops processing after N obsids without other side effects

**Functional and regression tests**

Ran these in https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr402/

```
# Long week and IR Zone holds
starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_flight
/home/jeanconn/git/starcheck_noinline/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_test
/proj/sot/ska/bin/diff2html dec2622a_flight.txt dec2622a_test.txt > dec2622a_diff.html

# Monitor star
starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_flight
/home/jeanconn/git/starcheck_noinline/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_test
/proj/sot/ska/bin/diff2html nov2822a_flight.txt nov2822a_test.txt > nov2822a_diff.html

# Maneuver only loads
starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_flight
/home/jeanconn/git/starcheck_noinline/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_test
/proj/sot/ska/bin/diff2html oct2422b_flight.txt oct2422b_test.txt > oct2422b_diff.html

# Replan
starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_flight
/home/jeanconn/git/starcheck_noinline/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_test
/proj/sot/ska/bin/diff2html may0521a_flight.txt may0521a_test.txt > may0521a_diff.html
```

To functionally test the change in the bad pixel check, I introduced a bad pixel near a guide star and compared outputs vs master.

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr402/badpixcheck/jan0923_master_badpix.html#obsid25550

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr402/badpixcheck/jan0923_noinline_badpix.html#obsid25550

Check is still functional.

Run of full regression test set revealed latent issue with #389 fixed in 5be93b4.  I compared this PR code to master + that same fix and the regression outputs show only two tiny, understood, and acceptable changes related to the PR update to the bad pixel test.
```
********************* 2005/JUL1105/oflsc ********************
********************* 2005/AUG2705/oflsb ********************
********************* 2005/NOV0705/oflsb ********************
********************* 2005/MAR0705/oflsb ********************
********************* 2006/MAR0606/oflsc ********************
********************* 2006/NOV1306/oflsa ********************
********************* 2006/AUG0706/oflsb ********************
********************* 2006/DEC2506/oflsc ********************
********************* 2006/MAR0606/oflsc ********************
********************* 2006/NOV2006/oflsb ********************
********************* 2007/MAR0507/oflsa ********************
********************* 2007/AUG0607/oflsa ********************
********************* 2007/AUG1407/oflsa ********************
********************* 2007/DEC1007/oflsb ********************
********************* 2007/MAR0507/oflsa ********************
********************* 2007/SEP0307/oflsa ********************
********************* 2008/JUL0708/oflsb ********************
********************* 2008/MAY0508/oflsa ********************
********************* 2008/AUG1808/oflsa ********************
********************* 2008/SEP0108/oflsb ********************
********************* 2008/SEP2908/oflsb ********************
********************* 2009/APR2009/oflsc ********************
********************* 2009/FEB1609/oflsa ********************
********************* 2009/FEB2309/oflsc ********************
********************* 2009/JUL0609/oflsb ********************
********************* 2009/JUN2209/oflsb ********************
********************* 2009/NOV3009/oflsb ********************
--- /home/jeanconn/git/starcheck_noinline/test_regress/release/2009/NOV3009/oflsb/starcheck.txt	2023-01-05 17:46:27.310431000 -0500
+++ /home/jeanconn/git/starcheck_noinline/test_regress/fido.cfa.harvard.edu_48d754734f76c6d488de6d18f96188ba4380c1e4/2009/NOV3009/oflsb/starcheck.txt	2023-01-05 23:10:38.313098000 -0500
@@ -81,7 +81,7 @@
 OBSID = 11935 at 2009:339:14:45:41.729   7.5 ACQ | 5.0 GUI | Critical:11 Caution:16
 OBSID = 11936 at 2009:339:15:53:45.926   7.6 ACQ | 5.0 GUI | Critical:10 Caution: 9
 OBSID = 11937 at 2009:339:16:35:42.174   7.6 ACQ | 5.0 GUI | Critical: 9 Caution: 8
-OBSID = 11938 at 2009:339:17:00:52.174   6.5 ACQ | 5.0 GUI | Critical:11 Caution:12
+OBSID = 11938 at 2009:339:17:00:52.174   6.5 ACQ | 5.0 GUI | Critical:10 Caution:12
 OBSID = 11939 at 2009:339:17:26:02.174   7.7 ACQ | 5.0 GUI | Critical:10 Caution: 9
 OBSID = 12037 at 2009:339:17:51:13.756   7.3 ACQ | 5.0 GUI | Critical:11 Caution:11
          ------  2009:340:03:45:00.000   OBC Load Segment Begins     CL340:0304 
@@ -1905,7 +1905,6 @@
 >> CRITICAL: [ 4] Readout Size. 6x6 Should be 8x8
 >> CRITICAL: [ 5] Readout Size. 6x6 Should be 8x8
 >> CRITICAL: [ 6] Readout Size. 6x6 Should be 8x8
->> CRITICAL: [ 7] Nearby ACA bad pixel.  row, col (-319, -299), dy, dz (5, 44) 
 >> CRITICAL: [ 7] Readout Size. 6x6 Should be 8x8
 >> CRITICAL: [ 8] Readout Size. 6x6 Should be 8x8
 >> CRITICAL: [ 9] Readout Size. 6x6 Should be 8x8
********************* 2009/OCT0509/oflsa ********************
********************* 2009/DEC2109/oflsb ********************
********************* 2010/APR1110/oflsb ********************
********************* 2010/APR1210/oflsa ********************
********************* 2010/JAN1110/oflsa ********************
********************* 2010/JUL0510/oflsb ********************
********************* 2010/OCT1110/oflsb ********************
********************* 2010/OCT2510/oflsb ********************
********************* 2011/JAN1711/oflsa ********************
********************* 2011/MAR1411/oflsa ********************
********************* 2011/APR0411/oflsa ********************
********************* 2011/DEC1211/oflsa ********************
********************* 2012/JAN3012/oflsa ********************
********************* 2013/JUL2913/oflsa ********************
********************* 2014/JAN2514/oflsa ********************
********************* 2015/JAN1215/oflsb ********************
--- /home/jeanconn/git/starcheck_noinline/test_regress/release/2015/JAN1215/oflsb/starcheck.txt	2023-01-05 18:45:24.075190000 -0500
+++ /home/jeanconn/git/starcheck_noinline/test_regress/fido.cfa.harvard.edu_48d754734f76c6d488de6d18f96188ba4380c1e4/2015/JAN1215/oflsb/starcheck.txt	2023-01-05 23:52:48.696908000 -0500
@@ -1063,7 +1063,7 @@
 [ 7]  6   185210664   BOT  8x8   0.955   9.205  10.703   1782    555  20   1  120          
 [ 8]  7   185339360   BOT  8x8   0.973   8.591  10.094   -407  -2098  20   1  120          
 
->> CRITICAL: [ 6] Nearby ACA bad pixel.  row, col (-318, -296), dy, dz (2, 25) 
+>> CRITICAL: [ 6] Nearby ACA bad pixel.  row, col (-317, -296), dy, dz (2, 25) 
 >> CAUTION : [1] Guide sum mag diff from agasc mag   0.08276
 >> CAUTION : [2] Guide sum mag diff from agasc mag   0.28450
 >> CAUTION : [3] Guide sum mag diff from agasc mag   0.02349
********************* 2015/DEC1115/oflsa ********************
********************* 2015/DEC1115/oflsb ********************
```


#### Performance
This branch runs about 50% slower. For DEC1922A this means about 90 seconds in this branch vs. 60 seconds in master.