### PR TITLE
set exit code 0 at the end

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -1301,3 +1301,5 @@ Tom Aldcroft ( taldcroft@cfa.harvard.edu )
 
 =cut
 
+exit 0
+


### PR DESCRIPTION
## Description

This PR sets the exit code to `0` at the end of execution.

I can confirm that the current master version return code is not zero. This causes `test_regress.sh` to fail. Someone who is more familiar with perl should check this.

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests

- [x] No unit tests

### Functional tests

I checked that the program runs and returns the given value using the same command as in `test_regress.sh`:
```
starcheck -dir $SKA/data/ska_testr/test_loads/2019/MAY2019/oflsa
```

I did not check an error elsewhere to make sure the error is properly set. I would need to know what error to check for.
