### PR TITLE
Save and return exit status at END

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -1165,6 +1165,10 @@ sub usage
 }
 
 END {
+    # Keep and return program exit status at end of END.
+    my $exit_status = $?;
+
+    # If the Python process id is defined, kill that process and wait
     if (defined $pid) {
 	if ($par{verbose} gt 1){
 	    my $server_calls = call_python("get_server_calls");
@@ -1178,6 +1182,7 @@ END {
 	kill 9, $pid;                    # must it be 9 (SIGKILL)?
         my $gone_pid = waitpid $pid, 0;  # then check that it's gone
     }
+    exit($exit_status);
 };
 
 =pod


### PR DESCRIPTION
## Description

Save and regurgitate exit status at END

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes ska_testr run test which was implicitly checking exit status.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I confirmed that the "nominal exit" code is now 0 instead of 9 and that simple errors for missing or not existing directories for products give non-zero status:
```
Using bad_pixel file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/ACABadPixels
Using acq_star_rdb file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/bad_acq_stars.rdb
Using gui_star_rdb file /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/bad_gui_stars.rdb
Reading backstop file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/CR140_0101.backstop
Reading DOT file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/mps/mdMAY2019A.dot
Reading TLR file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/CR140_0101.tlr
Reading MM file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/mps/mmMAY2019A.sum
Reading process summary /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/mps/msMAY2019A.sum
Reading mech check file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/output/TEST_mechcheck.txt
Reading OR file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/mps/or/MAY2019_A.or
Reading FIDSEL file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/History/FIDSEL.txt
Reading Maneuver Error file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/output/MAY2019A_ManErr.txt
Getting dither state from kadi at 2019:140:00:57:00.000 
Reading DITHER file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/History/DITHER.txt
Reading RADMON file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/History/RADMON.txt
Read 258 ACA bad pixels from /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/ACABadPixels
Read 46 bad AGASC IDs from /proj/sot/ska/jeanproj/git/starcheck/starcheck/data/agasc.bad
#####################################################################
# calc_ccd_temps run at Mon Jan  9 12:47:10 2023 by jeanconn
# Continuity run_start_time = 2023:009:17:47:09.830
# calc_ccd_temps version = 14.0.1.dev1+gcc6be07
# chandra_models version = 3.45
# kadi version = 7.2.0
#####################################################################

Using backstop file /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/CR140_0101.backstop
Found 1277 backstop commands between 2019:140:00:57:00.000 and 2019:146:23:52:35.589
RLTT = 2019:140:00:57:00.000
sched_stop = 2019:146:23:52:35.589
Fetching telemetry between 2019:139:00:57:00.000 and 2019:140:00:57:00.000
Calculating ACA thermal model
Propagation initial time and ACA: 2019:140:00:45:58.816 -9.50
Making temperature check plots
Writing plot file sctest/ccd_temperature.png
Checking star catalog for obsid 48165
Checking star catalog for obsid 48164
Wrote HTML report to sctest.html
Wrote text report to sctest.txt
0
(ska3-flight-2022.13rc0) jeanconn-fido> ./sandbox_starcheck -dir NOT_DIRECTORY -out sctest -max_obsids 2; echo $?
ERROR: No backstop file matching NOT_DIRECTORY/*.backstop

 at ./starcheck/src/starcheck.pl line 39.
	main::__ANON__("\x{a}") called at ./starcheck/src/starcheck.pl line 1137
	main::get_file("NOT_DIRECTORY/*.backstop", "backstop", "required") called at ./starcheck/src/starcheck.pl line 144
2
(ska3-flight-2022.13rc0) jeanconn-fido> ./sandbox_starcheck -dir /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019/ -out sctest -max_obsids 2; echo $?
ERROR: No backstop file matching /proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019//*.backstop

 at ./starcheck/src/starcheck.pl line 39.
	main::__ANON__("\x{a}") called at ./starcheck/src/starcheck.pl line 1137
	main::get_file("/proj/sot/ska/data/ska_testr/test_loads/2019/MAY2019//*.backstop", "backstop", "required") called at ./starcheck/src/starcheck.pl line 144
255
(ska3-flight-2022.13rc0) jeanconn-fido> 
