### PR TITLE
Calculate maneuver times and angle from cmds, replace maneuver summary file

### DIFF
--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -4,6 +4,7 @@ from astropy.table import Table
 import numpy as np
 import Quaternion
 from Quaternion import Quat
+import math
 
 from parse_cm import read_backstop, read_or_list
 from Chandra.Time import DateTime
@@ -149,9 +150,13 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
             [m['final']['q1'], m['final']['q2'],
              m['final']['q3'], m['final']['q4']]))
 
-        angle = np.degrees(2 * np.arccos(q1.q.dot(q2.q)))
-        if angle > 180:
-            angle = 360 - angle
+        # Calculate maneuver angle using code borrowed from kadi
+        q_manvr_3 = np.abs(-q2.q[0] * q1.q[0] - q2.q[1] * q1.q[1]
+                           - q2.q[2] * q1.q[2] + q2.q[3] * -q1.q[3])
+        # 4th component is cos(theta/2)
+        if q_manvr_3 > 1:
+            q_manvr_3 = 1
+        angle = np.degrees(2 * math.acos(q_manvr_3))
 
         # Re-arrange the hopper maneuever structure to match the structure previously used
         # from Parse_CM_File.pm

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -84,8 +84,9 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
     bs = read_backstop(backstop_file)
 
     # Get initial state attitude and sim position from history
-    att_time, q1, q2, q3, q4 = recent_attitude_history(DateTime(bs[0]['date']).secs,
-                                            attitude_file)
+    att_time, q1, q2, q3, q4 = recent_attitude_history(
+        DateTime(bs[0]['date']).secs,
+        attitude_file)
     q = Quaternion.normalize([q1, q2, q3, q4])
     simfa_time, simfa = recent_sim_history(DateTime(bs[0]['date']).secs,
                                            simfocus_file)
@@ -141,36 +142,34 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
     # Make maneuver structure
     mm = []
     for m in sc.maneuvers:
-        q1 = Quaternion.normalize([m['initial']['q1'],
-                                    m['initial']['q2'],
-                                    m['initial']['q3'],
-                                    m['initial']['q4']])
+        q1 = Quaternion.normalize(
+            [m['initial']['q1'], m['initial']['q2'],
+             m['initial']['q3'], m['initial']['q4']])
         q1 = Quat(q=q1)
-        q2 = Quaternion.normalize([m['final']['q1'],
-                                  m['final']['q2'],
-                                  m['final']['q3'],
-                                  m['final']['q4']])
+        q2 = Quaternion.normalize(
+            [m['final']['q1'], m['final']['q2'],
+             m['final']['q3'], m['final']['q4']])
         q2 = Quat(q=q2)
         angle = sphere_dist(q1.ra, q1.dec, q2.ra, q2.dec)
 
         # Re-arrange the hopper maneuever structure to match the structure previously used
         # from Parse_CM_File.pm
         man = {'initial_obsid': m['initial']['obsid'],
-              'final_obsid': m['final']['obsid'],
-              'start_date': m['initial']['date'],
-              'stop_date': m['final']['date'],
-              'ra': q2.ra,
-              'dec': q2.dec,
-              'roll': q2.roll,
-              'dur': m['dur'],
-              'angle': angle,
-              'q1': m['final']['q1'],
-              'q2': m['final']['q2'],
-              'q3': m['final']['q3'],
-              'q4': m['final']['q4'],
-             'tstart': DateTime(m['initial']['date']).secs,
-             'tstop': DateTime(m['final']['date']).secs,
-             }
+               'final_obsid': m['final']['obsid'],
+               'start_date': m['initial']['date'],
+               'stop_date': m['final']['date'],
+               'ra': q2.ra,
+               'dec': q2.dec,
+               'roll': q2.roll,
+               'dur': m['dur'],
+               'angle': angle,
+               'q1': m['final']['q1'],
+               'q2': m['final']['q2'],
+               'q3': m['final']['q3'],
+               'q4': m['final']['q4'],
+               'tstart': DateTime(m['initial']['date']).secs,
+               'tstop': DateTime(m['final']['date']).secs,
+               }
         mm.append(man)
 
     # Do the attitude checks

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -102,7 +102,7 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
 
     or_list = None if or_list_file is None else read_or_list(or_list_file)
     if or_list is None:
-        err_lines.append('ERROR: No OR list provided, cannot check attitudes')
+        lines.append('ERROR: No OR list provided, cannot check attitudes')
         all_ok = False
 
     # If dynamical offsets file is available then load was planned using
@@ -129,7 +129,7 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
         if not set(doffs['obsid']).issubset(set(or_map)):
             all_ok = False
             obsid_mismatch = set(doffs['obsid']) - set(or_map)
-            err_lines.append('WARNING: Obsid in dynamic offsets table but missing in OR list {}'
+            lines.append('WARNING: Obsid in dynamic offsets table but missing in OR list {}'
                          .format(list(obsid_mismatch)))
 
     # Run the commands and populate attributes in `sc`, the spacecraft state.

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -7,7 +7,6 @@ from Quaternion import Quat
 
 from parse_cm import read_backstop, read_or_list
 from Chandra.Time import DateTime
-from agasc import sphere_dist
 import hopper
 
 

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -143,18 +143,16 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
     # Make maneuver structure
     mm = []
     for m in sc.maneuvers:
-        q1 = Quaternion.normalize(
+        q1 = Quat(q=Quaternion.normalize(
             [m['initial']['q1'], m['initial']['q2'],
-             m['initial']['q3'], m['initial']['q4']])
-        q1 = Quat(q=q1)
-        q2 = Quaternion.normalize(
+             m['initial']['q3'], m['initial']['q4']]))
+        q2 = Quat(q=Quaternion.normalize(
             [m['final']['q1'], m['final']['q2'],
-             m['final']['q3'], m['final']['q4']])
-        q2 = Quat(q=q2)
-        angle1 = sphere_dist(q1.ra, q1.dec, q2.ra, q2.dec)
-        angle2 = np.degrees(2 * np.arccos(q1.q.dot(q2.q)))
-        if angle2 > 180:
-            angle2 = 360 - angle2
+             m['final']['q3'], m['final']['q4']]))
+
+        angle = np.degrees(2 * np.arccos(q1.q.dot(q2.q)))
+        if angle > 180:
+            angle = 360 - angle
 
         # Re-arrange the hopper maneuever structure to match the structure previously used
         # from Parse_CM_File.pm
@@ -166,8 +164,7 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
                'dec': q2.dec,
                'roll': q2.roll,
                'dur': m['dur'],
-               'angle': angle2,
-               'sphere_dist': angle1,
+               'angle': angle,
                'q1': m['final']['q1'],
                'q2': m['final']['q2'],
                'q3': m['final']['q3'],

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import re
 from astropy.table import Table
+import numpy as np
 import Quaternion
 from Quaternion import Quat
 
@@ -150,7 +151,10 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
             [m['final']['q1'], m['final']['q2'],
              m['final']['q3'], m['final']['q4']])
         q2 = Quat(q=q2)
-        angle = sphere_dist(q1.ra, q1.dec, q2.ra, q2.dec)
+        angle1 = sphere_dist(q1.ra, q1.dec, q2.ra, q2.dec)
+        angle2 = np.degrees(2 * np.arccos(q1.q.dot(q2.q)))
+        if angle2 > 180:
+            angle2 = 360 - angle2
 
         # Re-arrange the hopper maneuever structure to match the structure previously used
         # from Parse_CM_File.pm
@@ -162,7 +166,8 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
                'dec': q2.dec,
                'roll': q2.roll,
                'dur': m['dur'],
-               'angle': angle,
+               'angle': angle2,
+               'sphere_dist': angle1,
                'q1': m['final']['q1'],
                'q2': m['final']['q2'],
                'q3': m['final']['q3'],

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -192,7 +192,7 @@ def run(backstop_file, or_list_file=None, attitude_file=None,
                     line = '{:5d}: {}'.format(obsid, message)
                 lines.append(line)
 
-    # Write the attitute report
+    # Write the attitude report
     if out is not None:
         with open(out, 'w') as fh:
             fh.writelines("\n".join(lines))

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2115,6 +2115,7 @@ sub print_report {
 "  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f arcsec  End= %s\n",
                     $c->{angle}, $c->{dur}, $c->{man_err},
                     substr(time2date($c->{tstop}), 0, 17));
+                $o .= sprintf("  MANVR: sphere_dist= %.2f deg\n", $c->{sphere_dist});
             }
             $o .= "\n";
         }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2115,7 +2115,6 @@ sub print_report {
 "  MANVR: Angle= %6.2f deg  Duration= %.0f sec  Slew err= %.1f arcsec  End= %s\n",
                     $c->{angle}, $c->{dur}, $c->{man_err},
                     substr(time2date($c->{tstop}), 0, 17));
-                $o .= sprintf("  MANVR: sphere_dist= %.2f deg\n", $c->{sphere_dist});
             }
             $o .= "\n";
         }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1867,14 +1867,14 @@ sub check_monitor_commanding {
     }
 
     # Now check in backstop commands for :
-    #  Dither is disabled (AODSDITH) 1 min prior to the end of the maneuver (EOM)
+    #  Dither is disabled (AODSDITH) 1 min - 10s prior to the end of the maneuver (EOM)
     #    to the target attitude.
-    #  The OFP Aspect Camera Process is restarted (AOACRSET) 3 minutes after EOM.
-    #  Dither is enabled (AOENDITH) 5 min after EOM
+    #  The OFP Aspect Camera Process is restarted (AOACRSET) 3 minutes - 10s after EOM.
+    #  Dither is enabled (AOENDITH) 5 min - 10s after EOM
     # ACA-040
 
     my $t_manv = $manv->{tstop};
-    my %dt = (AODSDITH => -60, AOACRSET => 180, AOENDITH => 300);
+    my %dt = (AODSDITH => -70, AOACRSET => 170, AOENDITH => 290);
     my %cnt = map { $_ => 0 } keys %dt;
     foreach $bs (grep { $_->{cmd} eq 'COMMAND_SW' } @{$backstop}) {
         my %param = Ska::Parse_CM_File::parse_params($bs->{params});

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -341,7 +341,7 @@ sub set_maneuver {
         foreach my $m (@{$mm}) {
             my $manvr_obsid = $m->{final_obsid};
 
-            # where manvr_dest is either the final_obsid of a maneuver or the eventual destination obsid
+# where manvr_dest is either the final_obsid of a maneuver or the eventual destination obsid
             # of a segmented maneuver
             if (   ($manvr_obsid eq $self->{dot_obsid})
                 && abs($m->{q1} - $c->{Q1}) < 1e-7

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -269,6 +269,7 @@ sub set_files {
         $self->{backstop},
         $self->{guide_summ},
         $self->{or_file},
+        $self->{mm_file},
         $self->{dot_file},
         $self->{tlr_file}
     ) = @_;
@@ -2087,6 +2088,11 @@ sub print_report {
         $self->{STARCHECK}, basename($self->{or_file}),
         $self->{obsid}
     ) if ($self->{or_file});
+    $o .= sprintf(
+        "<A HREF=\"%s/%s.html#%s\">MANVR</A> ",
+        $self->{STARCHECK}, basename($self->{mm_file}),
+        $self->{dot_obsid}
+    );
     $o .= sprintf(
         "<A HREF=\"%s/%s.html#%s\">DOT</A> ",
         $self->{STARCHECK}, basename($self->{dot_file}),

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -253,22 +253,21 @@ my %dot = %{$dot_ref};
 print "Reading TLR file $tlr_file\n";
 my @load_segments = Ska::Parse_CM_File::TLR_load_segments($tlr_file);
 
-
 my $att_report = "${STARCHECK}/pcad_att_check.txt";
 my $att_check = call_python(
-        "pcad_att_check.run",
-        [],
-        {
-            backstop_file => $backstop,
-            or_list_file => $or_file,
-            simtrans_file => $simtrans_file,
-            simfocus_file => $simfocus_file,
-            attitude_file => $attitude_file,
-            ofls_characteristics_file => $char_file,
-            dynamic_offsets_file => $aimpoint_file,
-            out => $att_report,
-        }
-    );
+    "pcad_att_check.run",
+    [],
+    {
+        backstop_file => $backstop,
+        or_list_file => $or_file,
+        simtrans_file => $simtrans_file,
+        simfocus_file => $simfocus_file,
+        attitude_file => $attitude_file,
+        ofls_characteristics_file => $char_file,
+        dynamic_offsets_file => $aimpoint_file,
+        out => $att_report,
+    }
+);
 
 my $mm = $att_check->{mm};
 
@@ -430,14 +429,8 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->set_star_catalog();
     $obs{$obsid}->set_maneuver($mm);
     $obs{$obsid}->set_manerr(@manerr) if (@manerr);
-    $obs{$obsid}->set_files(
-        $STARCHECK,
-        $backstop,
-        $guide_summ,
-        $or_file,
-        $dot_file,
-        $tlr_file
-    );
+    $obs{$obsid}
+      ->set_files($STARCHECK, $backstop, $guide_summ, $or_file, $dot_file, $tlr_file);
     $obs{$obsid}->set_fids($fidsel);
     $obs{$obsid}->set_ps_times(@ps) if ($ps_file);
     map { $obs{$obsid}->{$_} = $or{$obsid}{$_} } keys %{ $or{$obsid} }

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -146,6 +146,7 @@ my $backstop =
   get_file("$par{dir}/${sosa_dir_slash}*.backstop", 'backstop', 'required');
 my $guide_summ = get_file("$par{dir}/mps/mg*.sum", 'guide summary');
 my $or_file = get_file("$par{dir}/mps/or/*.or", 'OR');
+my $mm_file = get_file("$par{dir}/mps/mm*.sum", 'maneuver');
 my $dot_file = get_file("$par{dir}/mps/md*.dot", 'DOT', 'required');
 my $mech_file =
   get_file("$par{dir}/${sosa_dir_slash}output/${sosa_prefix}TEST_mechcheck.txt*",
@@ -429,8 +430,15 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->set_star_catalog();
     $obs{$obsid}->set_maneuver($mm);
     $obs{$obsid}->set_manerr(@manerr) if (@manerr);
-    $obs{$obsid}
-      ->set_files($STARCHECK, $backstop, $guide_summ, $or_file, $dot_file, $tlr_file);
+    $obs{$obsid}->set_files(
+        $STARCHECK,
+        $backstop,
+        $guide_summ,
+        $or_file,
+        $mm_file,
+        $dot_file,
+        $tlr_file
+    );
     $obs{$obsid}->set_fids($fidsel);
     $obs{$obsid}->set_ps_times(@ps) if ($ps_file);
     map { $obs{$obsid}->{$_} = $or{$obsid}{$_} } keys %{ $or{$obsid} }
@@ -931,6 +939,7 @@ qq{<BODY><div id="overDiv" style="position:absolute; visibility:hidden; z-index:
     make_annotated_file('', ' ID=\s+', ', ', $backstop);
     make_annotated_file($guide_summ_start, '^\s+ID:\s+', '\S\S', $guide_summ);
     make_annotated_file('', '^ ID=', ', ', $or_file) if ($or_file);
+    make_annotated_file('', ' ID:\s+', '\S\S', $mm_file);
     make_annotated_file('', 'OBSID,ID=', ',', $dot_file);
     my $tlr_lines = add_obsid_to_tlr(\@bs, $tlr_file);
     make_annotated_file('', 'OBSERVATION ID\s*', '\s*\(', $tlr_file, $tlr_lines);

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -26,7 +26,6 @@ import starcheck
 from starcheck import __version__ as version
 from starcheck.calc_ccd_temps import get_ccd_temps
 from starcheck.check_ir_zone import ir_zone_ok
-from starcheck.pcad_att_check import make_pcad_attitude_check_report
 from starcheck.plot import make_plots_for_obsid
 
 ACQS = mica.stats.acq_stats.get_stats()
@@ -102,10 +101,6 @@ def get_kadi_scenario():
 def get_data_dir():
     sc_data = os.path.join(os.path.dirname(starcheck.__file__), "data")
     return sc_data if os.path.exists(sc_data) else ""
-
-
-def _make_pcad_attitude_check_report(**kwargs):
-    return make_pcad_attitude_check_report(**kwargs)
 
 
 def make_ir_check_report(**kwargs):


### PR DESCRIPTION
## Description
Calculate maneuvers from backstop cmds and replace maneuver summary as source of maneuver times and angle.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This fixes the known issue that the maneuver summary file is incorrect for observations with nonzero MANSTART.
Fixes #409 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Starcheck text output changed slightly, no impact to parsing tools:
- Maneuver end time changed by 10 seconds (new value is correct)

## Testing
Tested with ska3-matlab 2023.4rc6 on fido, though for these changes no special test setup should be required.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests

Used the "new" regression test set we used to review https://github.com/sot/starcheck/pull/402 plus two weeks with MANSTART values that caused issues with maneuver end times in flight starcheck
```
jeanconn-fido> more run.sh
jeanconn-fido> more run.sh
# Long week and IR Zone holds
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_flight
/proj/sot/ska/bin/diff2html dec2622a_flight.txt dec2622a_test.txt > dec2622a_diff.html

# Monitor star
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_flight
/proj/sot/ska/bin/diff2html nov2822a_flight.txt nov2822a_test.txt > nov2822a_diff.html

# Maneuver only loads
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_flight
/proj/sot/ska/bin/diff2html oct2422b_flight.txt oct2422b_test.txt > oct2422b_diff.html

# Replan
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_flight
/proj/sot/ska/bin/diff2html may0521a_flight.txt may0521a_test.txt > may0521a_diff.html

# MANSTART in APR0323A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -out apr0323a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -out apr0323a_flight
/proj/sot/ska/bin/diff2html apr0323a_flight.txt apr0323a_test.txt > apr0323a_diff.html

# MANSTART in APR1723A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -out apr1723a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -out apr1723a_flight
/proj/sot/ska/bin/diff2html apr1723a_flight.txt apr1723a_test.txt > apr1723a_diff.html

# JUN1923 week big dither
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_flight
/proj/sot/ska/bin/diff2html jun1923a_flight.txt jun1923a_test.txt > jun1923a_diff.html
```
Output in https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr408/

#### Test Review

@taldcroft looked through all the diffs and found only expected changes.