### PR TITLE
Set plot ymin relative to planning not penalty limit

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -520,7 +520,7 @@ def make_check_plots(outdir, states, times, temps, tstart, tstop, char):
     logger.info('Making temperature check plots')
     for fig_id, msid in enumerate(('aca',)):
         temp_ymax = max(char.aca_t_ccd_planning_limit, np.max(temps))
-        temp_ymin = min(char.aca_t_ccd_penalty_limit, np.min(temps))
+        temp_ymin = min(char.aca_t_ccd_planning_limit - 1, np.min(temps))
         plots[msid] = plot_two(fig_id=fig_id + 1,
                                x=times,
                                y=temps,


### PR DESCRIPTION
## Description

Set ACA t_ccd model temperature plot ymin relative to planning not penalty limit.  This will be useful if the penalty limit is removed.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] OSX

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I set a local version of the ACA thermal model chandra_model to have planning limit -15 and penalty limit 0C and ran on the JUL1723A schedule.

![ccd_temperature_mock_15](https://github.com/sot/starcheck/assets/791508/6d91d7a0-605d-4388-a8d4-64d3dacf1897)

This is the JUL1723A output with the current thermal model limits

![ccd_temperature_jul1723](https://github.com/sot/starcheck/assets/791508/c924ba9c-593e-46ce-afde-a6ece4cb0d4d)

As expected, this PR sets the Y minimum to the minimum of the data or the planning limit - 1.  I needed to move the planning limit *lower* to see that the plot change, as most schedules have a data range in which the y min on the plot is driven by the y min of the model data.

