### PR TITLE
Update for expanded high-IR zone 

### DIFF
--- a/starcheck/check_ir_zone.py
+++ b/starcheck/check_ir_zone.py
@@ -29,7 +29,7 @@ def ir_zone_ok(backstop_file, out=None):
     out_text = ["IR ZONE CHECKING"]
     for perigee_time in perigee_cmds['time']:
 
-        # Current pad is from 30 minutes before to 20 minutes after
+        # Current high ir zone is from 30 minutes before to 20 minutes after
         ir_zone_start = perigee_time - 30 * 60
         ir_zone_stop = perigee_time + 20 * 60
         out_text.append(

--- a/starcheck/check_ir_zone.py
+++ b/starcheck/check_ir_zone.py
@@ -5,9 +5,7 @@ import kadi.commands.states
 from cxotime import CxoTime
 
 
-def ir_zone_ok(backstop_file, out=None, pad_minutes=30):
-
-    pad_seconds = pad_minutes * 60
+def ir_zone_ok(backstop_file, out=None):
 
     bs_cmds = kadi.commands.get_cmds_from_backstop(backstop_file)
     bs_dates = bs_cmds['date']
@@ -30,8 +28,10 @@ def ir_zone_ok(backstop_file, out=None, pad_minutes=30):
     all_ok = True
     out_text = ["IR ZONE CHECKING"]
     for perigee_time in perigee_cmds['time']:
-        ir_zone_start = perigee_time - pad_seconds
-        ir_zone_stop = perigee_time
+
+        # Current pad is from 30 minutes before to 20 minutes after
+        ir_zone_start = perigee_time - 30 * 60
+        ir_zone_stop = perigee_time + 20 * 60
         out_text.append(
             f"Checking perigee at {CxoTime(perigee_time).date}")
         out_text.append(


### PR DESCRIPTION
## Description

Extend the high IR zone to 20 minutes after perigee for the high IR zone keep-out check.



## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests

Ran on one week (JUN0523) with the previous pre-perigee zone, and two weeks (JUN1923 and JUN2623) with the new 30-before-20-after zone in products.

Output at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr413


```
jeanconn-fido> more run.sh
# JUN0523 week 
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN0523/oflsa -out jun0523a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2023/JUN0523/oflsa -out jun0523a_flight
/proj/sot/ska/bin/diff2html jun0523a_flight.txt jun0523a_test.txt > jun0523a_diff.html

# JUN1923 week 
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_flight
/proj/sot/ska/bin/diff2html jun1923a_flight.txt jun1923a_test.txt > jun1923a_diff.html

# JUN2623 week 
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN2623/oflsa -out jun2623a_test
/proj/sot/ska3/flight/bin/starcheck -dir /data/mpcrit1/mplogs/2023/JUN2623/oflsa -out jun2623a_flight
/proj/sot/ska/bin/diff2html jun2623a_flight.txt jun2623a_test.txt > jun2623a_diff.html
```
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

