### PR TITLE
Check the pixel mode for ORs is set to ORIG

### DIFF
--- a/starcheck/check_ir_zone.py
+++ b/starcheck/check_ir_zone.py
@@ -1,7 +1,5 @@
 import numpy as np
-
 import kadi.commands
-import kadi.commands.states
 from cxotime import CxoTime
 
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -657,7 +657,7 @@ sub check_pixel_mode {
 
     unless (defined $obs_tstart) {
         push @{ $self->{warn} },
-          "Cannot determine obs start time for pixel mode not checking.\n";
+          "Cannot determine obs start time for pixel mode. Not checking.\n";
         return;
     }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -643,6 +643,36 @@ sub set_star_catalog {
 }
 
 #############################################################################################
+sub check_pixel_mode {
+#############################################################################################
+    my $self = shift;
+    my $pixel_states = shift;
+
+    # if this is an ER, just return
+    return if (($self->{obsid} =~ /^\d+$/ && $self->{obsid} >= $ER_MIN_OBSID));
+
+    # set the observation start as the end of the maneuver
+    my $obs_tstart = $self->{obs_tstart};
+    my $obs_tstop = $self->{obs_tstop};
+
+    unless (defined $obs_tstart) {
+        push @{ $self->{warn} },
+          "Cannot determine obs start time for pixel mode not checking.\n";
+        return;
+    }
+
+    # Check pixel mode during the dwell
+    my $pixel_mode_ok =
+      call_python("utils.pixel_mode_ok", [ $obs_tstart, $obs_tstop, $pixel_states ],);
+
+    if (not $pixel_mode_ok) {
+        push @{ $self->{warn} },
+          "PEA pixel mode not set to ORIG for dwell.\n";
+    }
+
+}
+
+#############################################################################################
 sub check_dither {
 #############################################################################################
     my $self = shift;

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -716,7 +716,7 @@ if (@global_warn) {
 $out .= "------------  HIGH IR ZONE CHECK  -----------------\n\n";
 my $ir_report = "${STARCHECK}/high_ir_check.txt";
 my $ir_ok = call_python(
-    "utils.make_ir_check_report",
+    "check_ir_zone.ir_zone_ok",
     [],
     {
         backstop_file => $backstop,

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -601,6 +601,8 @@ if ($obsid_temps) {
     }
 }
 
+my $pixel_states = call_python("utils.get_pixel_states", [$backstop]);
+
 # Do main checking
 foreach my $obsid (@obsid_id) {
     $obs{$obsid}->get_agasc_stars($agasc_file);
@@ -639,6 +641,7 @@ foreach my $obsid (@obsid_id) {
         $obs{$obsid}->check_momentum_unload(\@bs);
         $obs{$obsid}->check_bright_perigee($radmon);
         $obs{$obsid}->check_guide_count();
+        $obs{$obsid}->check_pixel_mode($pixel_states);
     }
 
     # Make sure there is only one star catalog per obsid

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -103,10 +103,6 @@ def get_data_dir():
     return sc_data if os.path.exists(sc_data) else ""
 
 
-def make_ir_check_report(**kwargs):
-    return ir_zone_ok(**kwargs)
-
-
 def get_dither_kadi_state(date):
     cols = [
         "dither",


### PR DESCRIPTION
## Description
Check the PEA pixel mode for ORs is set to ORIG

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing

<!-- If relevant describe any special setup for testing. -->
Tested out of ska3-matlab-2023.4rc6 though that should not be required.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

I edited JUL0323A backstop to remove the first command to switch back to ORIG after perigee for this output:

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr414/jul0323a_orig_removed.html

I edited JUL0323A backstop to move the first command to switch back to ORIG after perigee to be in the next OR for this output:

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr414/jul0323a_orig_moved.html


