### PR TITLE
Ignore mag clipping chandra_aca warnings

### DIFF
--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+import warnings
 
 import agasc
 import cxotime
@@ -30,6 +31,12 @@ from starcheck.plot import make_plots_for_obsid
 
 ACQS = mica.stats.acq_stats.get_stats()
 GUIDES = mica.stats.guide_stats.get_stats()
+
+# Ignore warnings about clipping the acquisition model magnitudes
+# from chandra_aca.star_probs
+warnings.filterwarnings(
+    "ignore", category=UserWarning,
+    message=r"\nModel .* computed between .* clipping input mag\(s\) outside that range\.")
 
 
 def date2secs(val):


### PR DESCRIPTION
## Description

Ignore mag clipping chandra_aca star_probs warnings from the acquisition model.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #414 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->


On fido/linux, with CHANDRA_MODELS_REPO_DIR set to /home/jeanconn/git/chandra_models and that repo checked out to have a version of the recent acquisition model in it, I confirmed that master gives these warnings

```
Writing plot file jul0323t/ccd_temperature.png
/fido.real/conda/envs/ska3-matlab-2023.4rc6/lib/python3.10/site-packages/chandra_aca/star_probs.py:349: UserWarning: 
Model grid-* computed between mag <= 5.0 <= 10.75, clipping input mag(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 44375
```
and they aren't present with this PR.
```
Writing plot file jul0323t/ccd_temperature.png
Checking star catalog for obsid 44375
Checking star catalog for obsid 44374
```
