### PR TITLE
Add a unit test for dyn bgd hotpix imposter calc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,14 @@
 from setuptools import setup
 
 
-setup(name='starcheck',
-      use_scm_version=True,
-      setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
-      author='Jean Connelly',
-      author_email='jconnelly@cfa.harvard.edu',
-      packages=['starcheck'],
-      include_package_data=True,
-      scripts=['starcheck/src/starcheck'],
-      )
+setup(
+    name="starcheck",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
+    author="Jean Connelly",
+    author_email="jconnelly@cfa.harvard.edu",
+    packages=["starcheck", "starcheck.tests"],
+    test_requires=["pytest"],
+    include_package_data=True,
+    scripts=["starcheck/src/starcheck"],
+)

--- a/starcheck/__init__.py
+++ b/starcheck/__init__.py
@@ -3,3 +3,12 @@
 import ska_helpers
 
 __version__ = ska_helpers.get_version(__package__)
+
+
+def test(*args, **kwargs):
+    """
+    Run py.test unit tests.
+    """
+    import testr
+
+    return testr.test(*args, **kwargs)

--- a/starcheck/pcad_att_check.py
+++ b/starcheck/pcad_att_check.py
@@ -48,7 +48,7 @@ def recent_sim_history(time, file):
     parsing and the int cast of the parsed data.
     """
     for line in reversed(open(file).readlines()):
-        match = re.match('^(\d+\.\d+)\s+\|\s+(\S+)\s*$',
+        match = re.match(r'^(\d+\.\d+)\s+\|\s+(\S+)\s*$',
                          line)
         if match:
             greta_time, value = match.groups()
@@ -64,7 +64,7 @@ def recent_attitude_history(time, file):
     parsing.
     """
     for line in reversed(open(file).readlines()):
-        match = re.match('^(\d+\.\d+)\s+\|\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*', line)
+        match = re.match(r'^(\d+\.\d+)\s+\|\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*', line)
         if match:
             greta_time, q1, q2, q3, q4 = match.groups()
             if (DateTime(greta_time, format='greta').secs < time):

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -46,12 +46,6 @@ def test_check_dynamic_hot_pix():
     # These stars are in mag-sorted order so the bonus should be applied to the last two
     # Stars with idx 7 and 8 should have bonus-applied t_ccd
     dyn_bgd_dt_ccd = 4.0
-    for imposter in imposters2:
-        assert imposter["status"] == 0
-        if imposter["idx"] < 7:
-            assert imposter["t_ccd"] == t_ccd
-        else:
-            assert imposter["t_ccd"] == t_ccd - dyn_bgd_dt_ccd
 
     # The imposters should be the same except for t_ccd, offset, mag
     # as these dates were selected to have matching dark cal files

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -1,0 +1,70 @@
+from starcheck.utils import check_hot_pix
+
+
+def test_check_dynamic_hot_pix():
+    # Parameters of obsid 25274 from JUL0323A
+    idxs = [1, 2, 3, 4, 5, 6, 7, 8]
+    yags = [
+        -773.135672595873,
+        2140.37683262341,
+        -1826.2356726102,
+        -1380.0856717436,
+        -713.835673125859,
+        -1322.09192254126,
+        -2185.44191819395,
+        101.314326039055,
+    ]
+    zags = [
+        -1741.99192158156,
+        166.726825875404,
+        160.264325897248,
+        -2469.16691506774,
+        -436.641923465157,
+        -1728.21692250903,
+        -1033.99192330043,
+        1259.22057376853,
+    ]
+    mags = [7, 7, 7, 8.217, 9.052, 9.75, 10.407, 10.503]
+    types = ["FID", "FID", "FID", "BOT", "BOT", "BOT", "BOT", "BOT"]
+    t_ccd = -11.2132562902057
+    dither_y = 7.9989482672109
+    dither_z = 7.9989482672109
+
+    # Use a date before the PEA patch uplink
+    date = "2023:138"
+
+    imposters1 = check_hot_pix(
+        idxs, yags, zags, mags, types, t_ccd, date, dither_y, dither_z
+    )
+    # There is no bonus or penalty applied so the temperatures should all be the same as the
+    # input t_ccd
+    for imposter in imposters1:
+        assert imposter["status"] == 0
+        assert imposter["t_ccd"] == t_ccd
+
+    # Use a date after the PEA patch uplink
+    date = "2023:140"
+    imposters2 = check_hot_pix(
+        idxs, yags, zags, mags, types, t_ccd, date, dither_y, dither_z
+    )
+
+    # These stars are in mag-sorted order so the bonus should be applied to the last two
+    # Stars with idx 7 and 8 should have bonus-applied t_ccd
+    dyn_bgd_dt_ccd = 4.0
+    for imposter in imposters2:
+        assert imposter["status"] == 0
+        if imposter["idx"] < 7:
+            assert imposter["t_ccd"] == t_ccd
+        else:
+            assert imposter["t_ccd"] == t_ccd - dyn_bgd_dt_ccd
+
+    # The imposters should be the same except for t_ccd, offset, mag
+    # as these dates were selected to have matching dark cal files
+    for imposter1, imposter2 in zip(imposters1, imposters2):
+        assert imposter["dark_date"] == imposter2["dark_date"]
+        assert imposter1["idx"] == imposter2["idx"]
+        assert imposter1["bad2_row"] == imposter2["bad2_row"]
+        assert imposter1["bad2_col"] == imposter2["bad2_col"]
+        assert imposter1["bad2_mag"] <= imposter2["bad2_mag"]
+        assert imposter1["status"] == imposter2["status"]
+        assert imposter1["offset"] >= imposter2["offset"]

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -65,6 +65,15 @@ def test_check_dynamic_hot_pix():
         assert imposter1["idx"] == imposter2["idx"]
         assert imposter1["bad2_row"] == imposter2["bad2_row"]
         assert imposter1["bad2_col"] == imposter2["bad2_col"]
-        assert imposter1["bad2_mag"] <= imposter2["bad2_mag"]
-        assert imposter1["status"] == imposter2["status"]
-        assert imposter1["offset"] >= imposter2["offset"]
+        assert imposter1["t_ccd"] == t_ccd
+        assert imposter1["status"] == 0
+        assert imposter2["status"] == 0
+        if imposter1["idx"] < 7:
+            assert imposter2["t_ccd"] == imposter1["t_ccd"]
+            assert imposter1["bad2_mag"] == imposter2["bad2_mag"]
+            assert imposter1["offset"] == imposter2["offset"]
+        else:
+            assert imposter2["t_ccd"] == imposter1["t_ccd"] - dyn_bgd_dt_ccd        
+            assert imposter1["bad2_mag"] < imposter2["bad2_mag"]
+            assert imposter1["offset"] > imposter2["offset"]
+        

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -36,11 +36,6 @@ def test_check_dynamic_hot_pix():
     imposters1 = check_hot_pix(
         idxs, yags, zags, mags, types, t_ccd, date, dither_y, dither_z
     )
-    # There is no bonus or penalty applied so the temperatures should all be the same as the
-    # input t_ccd
-    for imposter in imposters1:
-        assert imposter["status"] == 0
-        assert imposter["t_ccd"] == t_ccd
 
     # Use a date after the PEA patch uplink
     date = "2023:140"

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -61,7 +61,7 @@ def test_check_dynamic_hot_pix():
     # The imposters should be the same except for t_ccd, offset, mag
     # as these dates were selected to have matching dark cal files
     for imposter1, imposter2 in zip(imposters1, imposters2):
-        assert imposter["dark_date"] == imposter2["dark_date"]
+        assert imposter1["dark_date"] == imposter2["dark_date"]
         assert imposter1["idx"] == imposter2["idx"]
         assert imposter1["bad2_row"] == imposter2["bad2_row"]
         assert imposter1["bad2_col"] == imposter2["bad2_col"]

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -386,6 +386,7 @@ def check_hot_pix(idxs, yags, zags, mags, types, t_ccd, date, dither_y, dither_z
                         "bad2_mag": float(imp_mags[0]),
                         "offset": float(offset),
                         "t_ccd": float(t_ccd),
+                        "dark_date": dark_props["date"],
                     }
                 )
             except Exception:


### PR DESCRIPTION
## Description
Add a unit test for dyn bgd hotpix imposter calc.  Maybe it is a bridge too far for the #412 PR, but we could start to accumulate Python unit tests here as we go.  This is not a particularly clean unit test; I suppose it would be better to ask sparkles what we want for dyn_bgd_n_faint and dyn_bgd_dt_ccd or some such?  But this does work as a functional test for the imposter calc.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This addresses the issue at the end of #412 that the functional testing of the imposter calculation was not demonstrated.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
I tested this with install testing into my ska3-matlab-2023.4rc6 environment.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
