### PR TITLE
Use ccd_temp instead of t_ccd from dark cal data

### DIFF
--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -326,7 +326,7 @@ def check_hot_pix(idxs, yags, zags, mags, types, t_ccd, date, dither_y, dither_z
         date=date, include_image=True, aca_image=True
     )
     dark = dark_props["image"]
-    dark_t_ccd = dark_props["t_ccd"]
+    dark_t_ccd = dark_props["ccd_temp"]
 
     def imposter_offset(cand_mag, imposter_mag):
         """


### PR DESCRIPTION
## Description
Use ccd_temp instead of t_ccd from dark cal data.
The 't_ccd' value is only available for acdc dark cals starting in 2019.  The ccd_temp value is equal to t_ccd for modern calibrations and exists for the older ones.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [X] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functionally, the ska_testr regression test runs MAY2019A as the test and that failed against master with:
```
Traceback (most recent call last):
  File "/Users/jean/miniconda3/envs/ska3-matlab-2023.4rc6/lib/python3.10/site-packages/starcheck/server.py", line 71, in handle
    result = func(*args, **kwargs)
  File "/Users/jean/miniconda3/envs/ska3-matlab-2023.4rc6/lib/python3.10/site-packages/starcheck/utils.py", line 329, in check_hot_pix
    dark_t_ccd = dark_props["t_ccd"]
KeyError: 't_ccd'
```
With this PR there is no exception.
