### PR TITLE
Downgrade bad guide data warning

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1344,7 +1344,7 @@ sub check_star_catalog {
                 $n_nbad = $db_stats->{gui_bad};
             }
             if ($n_nbad && $n_obs > $obs_min_cnt && $n_nbad / $n_obs > $obs_bad_frac) {
-                push @warn,
+                push @orange_warn,
                   sprintf "[%2d] Bad Guide Star. %s has bad data %2d of %2d attempts\n",
                   $i, $sid, $n_nbad, $n_obs;
             }


### PR DESCRIPTION
## Description
Downgrade bad guide star critical warning

Fixes #410 


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

I ran this and the most recent starcheck release (14.1.0) on JUN0523A in 

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr420

Relevant output is just the diff that shows that this change downgrades two Bad Guide Star warnings from CRITICAL to WARNING status.

```
1,2c1,2
<  ------------  Starcheck 14.1.0    -----------------
<  Run on Thu Jul 13 15:26:56 EDT 2023 by jeanconn from fido.cfa.harvard.edu
---
>  ------------  Starcheck 14.1.1.dev1+g3c6fd09    -----------------
>  Run on Thu Jul 13 15:22:08 EDT 2023 by jeanconn from fido.cfa.harvard.edu
89c89
< OBSID = 25715 at 2023:158:16:07:59.994   6.3 ACQ | 4.8 GUI | Critical: 1 Warn: 1 Caution: 9
---
> OBSID = 25715 at 2023:158:16:07:59.994   6.3 ACQ | 4.8 GUI | Warn: 2 Caution: 9
91c91
< OBSID = 25729 at 2023:159:07:44:05.688   6.0 ACQ | 4.8 GUI | Critical: 1 Caution:13
---
> OBSID = 25729 at 2023:159:07:44:05.688   6.0 ACQ | 4.8 GUI | Warn: 1 Caution:13
1436c1436
< >> CRITICAL: [ 6] Bad Guide Star. 1052122960 has bad data  1 of  3 attempts
---
> >> WARNING : [ 6] Bad Guide Star. 1052122960 has bad data  1 of  3 attempts
1515c1515
< >> CRITICAL: [ 7] Bad Guide Star. 1052122960 has bad data  1 of  3 attempts
---
> >> WARNING : [ 7] Bad Guide Star. 1052122960 has bad data  1 of  3 attempts
```
