### PR TITLE
Handle vehicle mode with custom filtered backstop

### DIFF
--- a/starcheck/calc_ccd_temps.py
+++ b/starcheck/calc_ccd_temps.py
@@ -407,7 +407,7 @@ def mock_telem_predict(states, stat=None):
 def get_bs_cmds(oflsdir):
     """Return commands for the backstop file in opt.oflsdir.
     """
-    backstop_file = globfile(os.path.join(oflsdir, 'CR*.backstop'))
+    backstop_file = globfile(os.path.join(oflsdir, '*.backstop'))
     logger.info('Using backstop file %s' % backstop_file)
     bs_cmds = kadi.commands.get_cmds_from_backstop(backstop_file)
     logger.info('Found %d backstop commands between %s and %s' %


### PR DESCRIPTION
## Description
Handle vehicle mode with custom filtered backstop

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that -vehicle mode does not run after #408 

## Interface impacts
In the case of "-vehicle" option, makes a new filtered backstop file in the output directory that is read in for all other command checks.

## Testing
<!-- If relevant describe any special setup for testing. -->
Unit tests run out of ska3-flight-2023.3rc8 on OSX 

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Testing was run with the /proj/sot/ska3/test/ environment set to 2023.3rc8 from fido.

#### Testing confirming new starcheck vehicle filtered backstop is reasonable.

For this, used a hybrid approach and used grep to remove science-only scs cmds and sed to filter the comma-space-comma issue on combined backstop -- and then diffed with the filtered backstop from this PR.  The diffs show the expected value that MP_OBSID commands are the only additional things included in our filtered backstop from this PR.
This script and outputs are in https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr421/compare_vbackstop_to_products/

```
# These diffs should just be MP_OBSID commands

# Long week and IR Zone holds
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -vehicle -out dec2622a_vtest
cat /data/mpcrit1/mplogs/2022/DEC2622/oflsa/*backstop | sed 's/, ,/,/g' |  \
    grep -v "SCS= 131" | grep -v "SCS= 132" | grep -v "SCS= 133" > dec2622a_grep.backstop
diff dec2622a_grep.backstop dec2622a_vtest/vehicle_filtered.backstop > dec2622a_vb_diff.txt


# Monitor star
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -vehicle -out nov2822a_vtest
cat /data/mpcrit1/mplogs/2022/NOV2822/oflsa/*backstop | sed 's/, ,/,/g' |  \
    grep -v "SCS= 131" | grep -v "SCS= 132" | grep -v "SCS= 133" > nov2822a_grep.backstop
diff nov2822a_grep.backstop nov2822a_vtest/vehicle_filtered.backstop > nov2822a_vb_diff.txt

# Maneuver only loads
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -vehicle -out oct2422b_vtest
cat /data/mpcrit1/mplogs/2022/OCT2422/oflsb/*backstop | sed 's/, ,/,/g' |  \
    grep -v "SCS= 131" | grep -v "SCS= 132" | grep -v "SCS= 133" > oct2422b_grep.backstop
diff oct2422b_grep.backstop oct2422b_vtest/vehicle_filtered.backstop > oct2422b_vb_diff.txt

# Replan
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -vehicle -out may0521a_vtest
cat /data/mpcrit1/mplogs/2021/MAY0521/oflsa/*backstop | sed 's/, ,/,/g' |  \
    grep -v "SCS= 131" | grep -v "SCS= 132" | grep -v "SCS= 133" > may0521a_grep.backstop
diff may0521a_grep.backstop may0521a_vtest/vehicle_filtered.backstop > may0521a_vb_diff.txt

# MANSTART in APR0323A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -vehicle -out apr0323a_vtest
cat /data/mpcrit1/mplogs/2023/APR0323/oflsa/*backstop | sed 's/, ,/,/g' |  \
    grep -v "SCS= 131" | grep -v "SCS= 132" | grep -v "SCS= 133" > apr0323a_grep.backstop
diff apr0323a_grep.backstop apr0323a_vtest/vehicle_filtered.backstop > apr0323a_vb_diff.txt

# MANSTART in APR1723A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -vehicle -out apr1723a_vtest
cat /data/mpcrit1/mplogs/2023/APR1723/oflsa/*backstop | sed 's/, ,/,/g' |  \
    grep -v "SCS= 131" | grep -v "SCS= 132" | grep -v "SCS= 133" > apr1723a_grep.backstop
diff apr1723a_grep.backstop apr1723a_vtest/vehicle_filtered.backstop > apr1723a_vb_diff.txt

# JUN1923 week big dither
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -vehicle -out jun1923a_vtest
cat /data/mpcrit1/mplogs/2023/JUN1923/oflsa/*backstop | sed 's/, ,/,/g' |  \
    grep -v "SCS= 131" | grep -v "SCS= 132" | grep -v "SCS= 133" > jun1923a_grep.backstop
diff jun1923a_grep.backstop jun1923a_vtest/vehicle_filtered.backstop > jun1923a_vb_diff.txt
```

#### Testing confirming there are no differences to the 14.0.1 release for the combined products

(this PR only changes vehicle outputs). The diffs are as-expected.

This script and outputs are in https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr421/compare_vs_14.1.0/

```
# Long week and IR Zone holds
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_test
/proj/sot/ska3/test/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_prevrelease
diff dec2622a_prevrelease.txt dec2622a_test.txt > dec2622a_diff.txt
/proj/sot/ska/bin/diff2html dec2622a_prevrelease.txt dec2622a_test.txt > dec2622a_diff.html

# Monitor star
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_test
/proj/sot/ska3/test/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_prevrelease
diff nov2822a_prevrelease.txt nov2822a_test.txt > nov2822a_diff.txt
/proj/sot/ska/bin/diff2html nov2822a_prevrelease.txt nov2822a_test.txt > nov2822a_diff.html

# Maneuver only loads
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_test
/proj/sot/ska3/test/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_prevrelease
diff oct2422b_prevrelease.txt oct2422b_test.txt > oct2422b_diff.txt
/proj/sot/ska/bin/diff2html oct2422b_prevrelease.txt oct2422b_test.txt > oct2422b_diff.html

# Replan
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_test
/proj/sot/ska3/test/bin/skare starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_prevrelease
diff may0521a_prevrelease.txt may0521a_test.txt > may0521a_diff.txt
/proj/sot/ska/bin/diff2html may0521a_prevrelease.txt may0521a_test.txt > may0521a_diff.html

# MANSTART in APR0323A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -out apr0323a_test
/proj/sot/ska3/test/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -out apr0323a_prevrelease
diff apr0323a_prevrelease.txt apr0323a_test.txt > apr0323a_diff.txt
/proj/sot/ska/bin/diff2html apr0323a_prevrelease.txt apr0323a_test.txt > apr0323a_diff.html


# MANSTART in APR1723A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -out apr1723a_test
/proj/sot/ska3/test/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -out apr1723a_prevrelease
diff apr1723a_prevrelease.txt apr1723a_test.txt > apr1723a_diff.txt
/proj/sot/ska/bin/diff2html apr1723a_prevrelease.txt apr1723a_test.txt > apr1723a_diff.html


# JUN1923 week big dither
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_test
/proj/sot/ska3/test/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_prevrelease
diff jun1923a_prevrelease.txt jun1923a_test.txt > jun1923a_diff.txt
/proj/sot/ska/bin/diff2html jun1923a_prevrelease.txt jun1923a_test.txt > jun1923a_diff.html
```

#### Confirm that diffs between combined and vehicle outputs look reasonable for this PR

Outputs in https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr421/vehicle_vs_combined

```
# Long week and IR Zone holds

/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_test
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -vehicle -out dec2622a_vtest
/proj/sot/ska/bin/diff2html dec2622a_test.txt dec2622a_vtest.txt > dec2622a_diff.html

# Monitor star
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_test
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -vehicle -out nov2822a_vtest
/proj/sot/ska/bin/diff2html nov2822a_test.txt nov2822a_vtest.txt > nov2822a_diff.html

# Maneuver only loads
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_test
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -vehicle -out oct2422b_vtest
/proj/sot/ska/bin/diff2html oct2422b_test.txt oct2422b_vtest.txt > oct2422b_diff.html

# Replan
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_test
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -vehicle -out may0521a_vtest
/proj/sot/ska/bin/diff2html may0521a_test.txt may0521a_vtest.txt > may0521a_diff.html

# MANSTART in APR0323A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -out apr0323a_test
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -vehicle -out apr0323a_vtest
/proj/sot/ska/bin/diff2html apr0323a_test.txt apr0323a_vtest.txt > apr0323a_diff.html


# MANSTART in APR1723A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -out apr1723a_test
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -vehicle -out apr1723a_vtest
/proj/sot/ska/bin/diff2html apr1723a_test.txt apr1723a_vtest.txt > apr1723a_diff.html


# JUN1923 week big dither
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_test
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -vehicle -out jun1923a_vtest
/proj/sot/ska/bin/diff2html jun1923a_test.txt jun1923a_vtest.txt > jun1923a_diff.html
```

#### Compare output of this PR to current flight

Outputs in https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr421/compare_vs_flight

This show the expected diffs due to several PRs, including all of the small timing differences due to #408 (use calculated maneuvers instead of maneuver summary) , the updates for #412 (apply dynamic background bonus), and #413 (use expanded high-IR zone).  I tried to reduce diffs a bit by setting the new run of starcheck to use chandra_models 3.48 with the previous version of the acquisition model.

The diffs show the expected small timing differences in maneuver end time for all observations.  Additionally, in the vehicle diffs there are tiny timing differences on the reference time used for gyro hold observations --  It looks like the time of the MP_OBSID command in the new filtered vehicle backstop ends up as the reference time for these observations in this new approach.  Previously it looks like they were assigned the time of the AOUPTARG command as the reference time. This is benign for these no-starcat observations.


```
export CHANDRA_MODELS_DEFAULT_VERSION=3.48

# Long week and IR Zone holds
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_test
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -out dec2622a_flight
diff dec2622a_flight.txt dec2622a_test.txt > dec2622a_diff.txt
/proj/sot/ska/bin/diff2html dec2622a_flight.txt dec2622a_test.txt > dec2622a_diff.html

# Monitor star
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_test
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -out nov2822a_flight
diff nov2822a_flight.txt nov2822a_test.txt > nov2822a_diff.txt
/proj/sot/ska/bin/diff2html nov2822a_flight.txt nov2822a_test.txt > nov2822a_diff.html

# Maneuver only loads
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_test
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -out oct2422b_flight
diff oct2422b_flight.txt oct2422b_test.txt > oct2422b_diff.txt
/proj/sot/ska/bin/diff2html oct2422b_flight.txt oct2422b_test.txt > oct2422b_diff.html

# Replan
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_test
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -out may0521a_flight
diff may0521a_flight.txt may0521a_test.txt > may0521a_diff.txt
/proj/sot/ska/bin/diff2html may0521a_flight.txt may0521a_test.txt > may0521a_diff.html

# MANSTART in APR0323A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -out apr0323a_test
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -out apr0323a_flight
diff apr0323a_flight.txt apr0323a_test.txt > apr0323a_diff.txt
/proj/sot/ska/bin/diff2html apr0323a_flight.txt apr0323a_test.txt > apr0323a_diff.html


# MANSTART in APR1723A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -out apr1723a_test
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -out apr1723a_flight
diff apr1723a_flight.txt apr1723a_test.txt > apr1723a_diff.txt
/proj/sot/ska/bin/diff2html apr1723a_flight.txt apr1723a_test.txt > apr1723a_diff.html


# JUN1923 week big dither
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_test
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -out jun1923a_flight
diff jun1923a_flight.txt jun1923a_test.txt > jun1923a_diff.txt
/proj/sot/ska/bin/diff2html jun1923a_flight.txt jun1923a_test.txt > jun1923a_diff.html

# Long week and IR Zone holds
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -vehicle -out dec2622a_vtest
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/DEC2622/oflsa -vehicle -out dec2622a_vflight
diff dec2622a_vflight.txt dec2622a_vtest.txt > dec2622a_vdiff.txt
/proj/sot/ska/bin/diff2html dec2622a_vflight.txt dec2622a_vtest.txt > dec2622a_vdiff.html

# Monitor star
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -vehicle -out nov2822a_vtest
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/NOV2822/oflsa -vehicle -out nov2822a_vflight
diff nov2822a_vflight.txt nov2822a_vtest.txt > nov2822a_vdiff.txt
/proj/sot/ska/bin/diff2html nov2822a_vflight.txt nov2822a_vtest.txt > nov2822a_vdiff.html

# Maneuver only loads
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -vehicle -out oct2422b_vtest
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/OCT2422/oflsb -vehicle -out oct2422b_vflight
diff oct2422b_vflight.txt oct2422b_vtest.txt > oct2422b_vdiff.txt
/proj/sot/ska/bin/diff2html oct2422b_vflight.txt oct2422b_vtest.txt > oct2422b_vdiff.html

# Replan
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -vehicle -out may0521a_vtest
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2021/MAY0521/oflsa -vehicle -out may0521a_vflight
diff may0521a_vflight.txt may0521a_vtest.txt > may0521a_vdiff.txt
/proj/sot/ska/bin/diff2html may0521a_vflight.txt may0521a_vtest.txt > may0521a_vdiff.html

# MANSTART in APR0323A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -vehicle -out apr0323a_vtest
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/APR0323/oflsa -vehicle -out apr0323a_vflight
diff apr0323a_vflight.txt apr0323a_vtest.txt > apr0323a_vdiff.txt
/proj/sot/ska/bin/diff2html apr0323a_vflight.txt apr0323a_vtest.txt > apr0323a_vdiff.html

# MANSTART in APR1723A
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -vehicle -out apr1723a_vtest
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/APR1723/oflsa -vehicle -out apr1723a_vflight
diff apr1723a_vflight.txt apr1723a_vtest.txt > apr1723a_vdiff.txt
/proj/sot/ska/bin/diff2html apr1723a_vflight.txt apr1723a_vtest.txt > apr1723a_vdiff.html


# JUN1923 week big dither
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -vehicle -out jun1923a_vtest
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/JUN1923/oflsa -vehicle -out jun1923a_vflight
diff jun1923a_vflight.txt jun1923a_vtest.txt > jun1923a_vdiff.txt
/proj/sot/ska/bin/diff2html jun1923a_vflight.txt jun1923a_vtest.txt > jun1923a_vdiff.html
```