### PR TITLE
WIP: Set maneuver match off commanded obsid

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -344,7 +344,7 @@ sub set_maneuver {
 
 # where manvr_dest is either the final_obsid of a maneuver or the eventual destination obsid
             # of a segmented maneuver
-            if (   ($manvr_obsid eq $self->{dot_obsid})
+            if (   ($manvr_obsid eq $self->{obsid})
                 && abs($m->{q1} - $c->{Q1}) < 1e-7
                 && abs($m->{q2} - $c->{Q2}) < 1e-7
                 && abs($m->{q3} - $c->{Q3}) < 1e-7)


### PR DESCRIPTION
## Description
Set maneuver match off commanded obsid

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This fixes the issue that after #408 , starcheck won't run on old products where the "dot obsid" or oflsid doesn't match the commanded obsid for many ERs.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
