### PR TITLE
Set 'too cold for fid placement' check to use acq t_ccd

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2882,10 +2882,10 @@ sub set_ccd_temps {
     }
 
     # Add CRITICAL if OR and too cold as fid lights may be out of boxes
-    if (($self->{obsid} < 38000) and ($self->{ccd_temp_min} < -14.0)) {
+    if (($self->{obsid} < 38000) and ($self->{ccd_temp_acq} < -14.0)) {
         push @{ $self->{warn} },
-          sprintf("OR with min(t_ccd) %.1f < -14. Fid lights may not be tracked\n",
-            $self->{ccd_temp_min});
+          sprintf("OR with acq t_ccd %.1f < -14. Fid lights may not be tracked\n",
+            $self->{ccd_temp_acq});
     }
 
     # Add info for having a penalty temperature too


### PR DESCRIPTION
## Description
Update the "too cold" warning to use the acquisition temperature, as this check is about fid lights.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Closes #386 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
Run against a recent ska3 masters env, though this is not required for this change.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [X] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Single regression/functional test output at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr424/

For obsid 26644 the violation of the -14C threshold would have happened at the end of the observation, so changing the check to be wrt acquisition temperature means that the warning is not thrown.

```  
(checkout starcheck master)
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2122/oflsa/ -out nov2122a_master
(checkout this PR branch)
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2122/oflsa/ -out nov2122a_test
diff -u nov2122a_master.txt nov2122a_test.txt > diff.txt
```