### PR TITLE
Planning t_ccd critical warning

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2875,7 +2875,7 @@ sub set_ccd_temps {
     $self->{ccd_temp_acq} = $obsid_temps->{ $self->{obsid} }->{ccd_temp_acq};
     $self->{n100_warm_frac} = $obsid_temps->{ $self->{obsid} }->{n100_warm_frac};
 
-    # Add info statement for limit violations
+    # Add critical warning for ACA planning limit violation
     if ($self->{ccd_temp} > $config{ccd_temp_red_limit}) {
         push @{ $self->{warn} },
           sprintf("CCD temperature exceeds %.1f C\n", $config{ccd_temp_red_limit});

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2877,7 +2877,7 @@ sub set_ccd_temps {
 
     # Add info statement for limit violations
     if ($self->{ccd_temp} > $config{ccd_temp_red_limit}) {
-        push @{ $self->{fyi} },
+        push @{ $self->{warn} },
           sprintf("CCD temperature exceeds %.1f C\n", $config{ccd_temp_red_limit});
     }
 


### PR DESCRIPTION
## Description

Change the "over the planning limit" warning to critical/red .


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
Output at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck-pr428/
```
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2023/JUL3123/oflsa -out jul3123a_flight
/proj/sot/ska3/flight/bin/skare /home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2023/JUL3123/oflsa -out jul3123a_test
diff -u jul3123a_flight.txt jul3123a_test.txt > diff.txt
```
The diffs also show the change due to https://github.com/sot/starcheck/pull/420 as the diffs are against flight not master starcheck output, which is acceptable in this case.
