### PR TITLE
Update acq model range warning for current grid model

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2888,13 +2888,13 @@ sub set_ccd_temps {
 
 # Clip the acq ccd temperature to the calibrated range of the grid acq probability model
     # and add a yellow warning to let the user know this has happened.
-    if (($self->{ccd_temp_acq} > -1.0) or ($self->{ccd_temp_acq} < -16.0)) {
+    if (($self->{ccd_temp_acq} > 2.0) or ($self->{ccd_temp_acq} < -15.0)) {
         push @{ $self->{yellow_warn} },
-          sprintf("acq t_ccd %.1f outside range -16.0 to -1.0. Clipped.\n",
+          sprintf("acq t_ccd %.1f outside range -15.0 to 2.0. Clipped.\n",
             $self->{ccd_temp_acq});
         $self->{ccd_temp_acq} =
-            $self->{ccd_temp_acq} > -1.0 ? -1.0
-          : $self->{ccd_temp_acq} < -16.0 ? -16.0
+            $self->{ccd_temp_acq} > 2.0 ? 2.0
+          : $self->{ccd_temp_acq} < -15.0 ? -15.0
           : $self->{ccd_temp_acq};
     }
 }


### PR DESCRIPTION
## Description

Update the temperature clipping for the acquisition model to clip to the range for the current grid-* model.  It would be better if this was taken from model itself, but this does not change frequently.


## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
(ska3-flight-latest) flame:starcheck jean$ git rev-parse HEAD
d668e7614b4eb598367a5b03618c12fd853f7118
(ska3-flight-latest) flame:starcheck jean$ pytest
=========================================================== test session starts ============================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 14 items                                                                                                                         

starcheck/tests/test_state_checks.py .............                                                                                   [ 92%]
starcheck/tests/test_utils.py .                                                                                                      [100%]

============================================================ 14 passed in 5.10
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Ran the SEP0417A week with some cold acquisition temperatures to see the warnings have changed.

[https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr426/combined_diff.txt](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr426/combined_diff.txt
)

New 
```
Checking star catalog for obsid 49798
Checking star catalog for obsid 18997
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 49797
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 49796
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 49795
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 49794
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 49793
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 49792
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 19650
/fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/chandra_aca/star_probs.py:423: UserWarning: 
Model grid-local-quadratic-2023-05.fits.gz computed between -15 <= t_ccd <= 2, clipping input t_ccd(s) outside that range.
  warnings.warn(
Checking star catalog for obsid 19653
Checking star catalog for obsid 19359
```
