### PR TITLE
Add fid offset support

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1971,6 +1971,13 @@ sub check_fids {
             {
                 $fidsel_ok = 1;
                 $fid_ok[$i_fid] = 1;
+                # Add a warning if the match is within 5 arcsecs of the edge
+                if ((   abs($yag - $c->{"YANG$i"}) > ($fid_hw - 5))
+                    |  (abs($zag - $c->{"ZANG$i"}) > ($fid_hw - 5)))
+                {
+                    push @{$self->{orange_warn}},
+                      "Fid $self->{SI} FIDSEL $fid within 5 arcsec of fid search box edge\n";
+                }
                 last;
             }
         }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2892,7 +2892,7 @@ sub set_ccd_temps {
 
     # Add CRITICAL if OR and temperature looks well out of range (fid drift model may be wrong)
     if (($self->{obsid} < 38000) and
-        (($self->{ccd_temp_acq} <= -20.0) or ($self->{ccd_temp_acq} >= 5.0))) {
+        (($self->{ccd_temp_acq} < -20.0) or ($self->{ccd_temp_acq} > 5.0))) {
         push @{ $self->{warn} },
           sprintf("OR with acq t_ccd %.1f not in -20 < t_ccd < 5. Fid positions uncalibrated.\n",
             $self->{ccd_temp_acq});

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1184,7 +1184,7 @@ sub check_star_catalog {
     # Match positions of fids in star catalog with expected, and verify a one to one
     # correspondance between FIDSEL command and star catalog.
     # Skip this for vehicle-only loads since fids will be turned off.
-    check_fids($self, $c, \@warn) unless $vehicle;
+    check_fids($self, $c) unless $vehicle;
 
     # store a list of the fid positions
     my @fid_positions =
@@ -1920,7 +1920,6 @@ sub check_fids {
 #############################################################################################
     my $self = shift;
     my $c = shift;    # Star catalog command
-    my $warn = shift;    # Array ref to warnings for this obsid
 
     my $fid_hw = 40;
 
@@ -1932,11 +1931,11 @@ sub check_fids {
 
     # Make sure we have SI and SIM_OFFSET_Z to be able to calculate fid yang and zang
     unless (defined $self->{SI}) {
-        push @{$warn}, "Unable to check fids because SI undefined\n";
+        push @{$self->{warn}}, "Unable to check fids because SI undefined\n";
         return;
     }
     unless (defined $self->{SIM_OFFSET_Z}) {
-        push @{$warn}, "Unable to check fids because SIM_OFFSET_Z undefined\n";
+        push @{$self->{warn}}, "Unable to check fids because SIM_OFFSET_Z undefined\n";
         return;
     }
 
@@ -1950,7 +1949,7 @@ sub check_fids {
           calc_fid_ang($fid, $self->{SI}, $self->{SIM_OFFSET_Z}, $self->{obsid});
 
         if ($error) {
-            push @{$warn}, "$error\n";
+            push @{$self->{warn}}, "$error\n";
             next;
         }
         my $fidsel_ok = 0;
@@ -1977,7 +1976,7 @@ sub check_fids {
         }
 
         # ACA-034
-        push @{$warn},
+        push @{$self->{warn}},
           sprintf(
 "Fid $self->{SI} FIDSEL $fid not found within $fid_hw arcsec of (%.1f, %.1f)\n",
             $yag, $zag)
@@ -1986,7 +1985,7 @@ sub check_fids {
 
     # ACA-035
     for $i_fid (0 .. $#fid_ok) {
-        push @{$warn},
+        push @{$self->{warn}},
 "Fid IDX=\[$self->{fid}[$i_fid]\] not within $fid_hw arcsec of an ON FIDSEL fid\n",
           unless ($fid_ok[$i_fid]);
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2890,10 +2890,11 @@ sub set_ccd_temps {
           sprintf("CCD temperature exceeds %.1f C\n", $config{ccd_temp_red_limit});
     }
 
-    # Add CRITICAL if OR and too cold as fid lights may be out of boxes
-    if (($self->{obsid} < 38000) and ($self->{ccd_temp_acq} < -14.0)) {
+    # Add CRITICAL if OR and temperature looks well out of range (fid drift model may be wrong)
+    if (($self->{obsid} < 38000) and
+        (($self->{ccd_temp_acq} <= -20.0) or ($self->{ccd_temp_acq} >= 5.0))) {
         push @{ $self->{warn} },
-          sprintf("OR with acq t_ccd %.1f < -14. Fid lights may not be tracked\n",
+          sprintf("OR with acq t_ccd %.1f not in -20 < t_ccd < 5. Fid positions uncalibrated.\n",
             $self->{ccd_temp_acq});
     }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1922,7 +1922,7 @@ sub check_fids {
     my $c = shift;    # Star catalog command
     my $warn = shift;    # Array ref to warnings for this obsid
 
-    my $fid_hw = 35;
+    my $fid_hw = 40;
 
     my (@fid_ok, @fidsel_ok);
     my ($i, $i_fid);

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1187,7 +1187,6 @@ sub check_star_catalog {
     my $fid_positions = get_fid_positions($self, $c);
     check_fids($self, $c, $fid_positions) unless $vehicle;
 
-
     # Make arrays of the items that we need for the hot pixel region check
     my (@idxs, @yags, @zags, @mags, @types);
     foreach my $i (1 .. 16) {
@@ -1914,7 +1913,7 @@ sub check_monitor_commanding {
 }
 
 #############################################################################################
-sub get_fid_positions{
+sub get_fid_positions {
 #############################################################################################
 
     my $self = shift;
@@ -1926,11 +1925,12 @@ sub get_fid_positions{
 
     # Make sure we have SI and SIM_OFFSET_Z to be able to calculate fid yang and zang
     unless (defined $self->{SI}) {
-        push @{$self->{warn}}, "Unable to check fids because SI undefined\n";
+        push @{ $self->{warn} }, "Unable to check fids because SI undefined\n";
         return \@fid_positions;
     }
     unless (defined $self->{SIM_OFFSET_Z}) {
-        push @{$self->{warn}}, "Unable to check fids because SIM_OFFSET_Z undefined\n";
+        push @{ $self->{warn} },
+          "Unable to check fids because SIM_OFFSET_Z undefined\n";
         return \@fid_positions;
     }
 
@@ -1940,12 +1940,12 @@ sub get_fid_positions{
           calc_fid_ang($fid, $self->{SI}, $self->{SIM_OFFSET_Z}, $self->{obsid});
 
         if ($error) {
-            push @{$self->{warn}}, "$error\n";
+            push @{ $self->{warn} }, "$error\n";
             next;
         }
 
-        my $offsets = call_python("utils.get_fid_offset",
-            [ $self->{date}, $self->{ccd_temp_acq} ]);
+        my $offsets =
+          call_python("utils.get_fid_offset", [ $self->{date}, $self->{ccd_temp_acq} ]);
         my $dy = $offsets->[0];
         my $dz = $offsets->[1];
         $yag += $dy;
@@ -1973,7 +1973,7 @@ sub check_fids {
     my @fid_ok = map { 0 } @{ $self->{fid} };
 
     # For each FIDSEL fid, confirm it is in a catalog search box
-    foreach my $fid (@{ $fid_positions }) {
+    foreach my $fid (@{$fid_positions}) {
 
         my ($yag, $zag) = ($fid->{y}, $fid->{z});
         my $fidsel_ok = 0;
@@ -1988,32 +1988,34 @@ sub check_fids {
             {
                 $fidsel_ok = 1;
                 $fid_ok[$i_fid] = 1;
+
                 # Add a warning if the match is within 5 arcsecs of the edge
-                if ((   abs($yag - $c->{"YANG$i"}) > ($fid_hw - 5))
-                    |  (abs($zag - $c->{"ZANG$i"}) > ($fid_hw - 5)))
+                if ((abs($yag - $c->{"YANG$i"}) > ($fid_hw - 5)) |
+                    (abs($zag - $c->{"ZANG$i"}) > ($fid_hw - 5)))
                 {
-                    push @{$self->{orange_warn}}, sprintf(
-                      "[%2d] expected fid pos within 5 arcsec of search box edge\n",
-                      $i);
+                    push @{ $self->{orange_warn} },
+                      sprintf(
+                        "[%2d] expected fid pos within 5 arcsec of search box edge\n",
+                        $i);
                 }
                 last;
             }
         }
 
         # ACA-034
-        push @{$self->{warn}},
+        push @{ $self->{warn} },
           sprintf(
-            "No catalog fid found within $fid_hw arcsec of fid turned on at (%.1f, %.1f)\n",
+"No catalog fid found within $fid_hw arcsec of fid turned on at (%.1f, %.1f)\n",
             $yag, $zag)
           unless ($fidsel_ok);
     }
 
     # ACA-035
     for my $i_fid (0 .. $#fid_ok) {
-        push @{$self->{warn}}, sprintf(
-"[%2d] catalog fid not within $fid_hw arcsec of an expected fid pos\n",
-            $self->{fid}[$i_fid]
-            )
+        push @{ $self->{warn} },
+          sprintf(
+            "[%2d] catalog fid not within $fid_hw arcsec of an expected fid pos\n",
+            $self->{fid}[$i_fid])
           unless ($fid_ok[$i_fid]);
     }
 }
@@ -2916,11 +2918,13 @@ sub set_ccd_temps {
           sprintf("CCD temperature exceeds %.1f C\n", $config{ccd_temp_red_limit});
     }
 
-    # Add CRITICAL if OR and temperature looks well out of range (fid drift model may be wrong)
-    if (($self->{obsid} < 38000) and
-        (($self->{ccd_temp_acq} < -20.0) or ($self->{ccd_temp_acq} > 5.0))) {
+# Add CRITICAL if OR and temperature looks well out of range (fid drift model may be wrong)
+    if (    ($self->{obsid} < 38000)
+        and (($self->{ccd_temp_acq} < -20.0) or ($self->{ccd_temp_acq} > 5.0)))
+    {
         push @{ $self->{warn} },
-          sprintf("OR with acq t_ccd %.1f not in -20 < t_ccd < 5. Fid positions uncalibrated.\n",
+          sprintf(
+"OR with acq t_ccd %.1f not in -20 < t_ccd < 5. Fid positions uncalibrated.\n",
             $self->{ccd_temp_acq});
     }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1992,8 +1992,9 @@ sub check_fids {
                 if ((   abs($yag - $c->{"YANG$i"}) > ($fid_hw - 5))
                     |  (abs($zag - $c->{"ZANG$i"}) > ($fid_hw - 5)))
                 {
-                    push @{$self->{orange_warn}},
-                      "Fid $self->{SI} FIDSEL $fid within 5 arcsec of fid search box edge\n";
+                    push @{$self->{orange_warn}}, sprintf(
+                      "[%2d] expected fid pos within 5 arcsec of search box edge\n",
+                      $i);
                 }
                 last;
             }
@@ -2002,15 +2003,17 @@ sub check_fids {
         # ACA-034
         push @{$self->{warn}},
           sprintf(
-"Fid $self->{SI} FIDSEL $fid not found within $fid_hw arcsec of (%.1f, %.1f)\n",
+            "No catalog fid found within $fid_hw arcsec of fid turned on at (%.1f, %.1f)\n",
             $yag, $zag)
           unless ($fidsel_ok);
     }
 
     # ACA-035
     for my $i_fid (0 .. $#fid_ok) {
-        push @{$self->{warn}},
-"Fid IDX=\[$self->{fid}[$i_fid]\] not within $fid_hw arcsec of an ON FIDSEL fid\n",
+        push @{$self->{warn}}, sprintf(
+"[%2d] catalog fid not within $fid_hw arcsec of an expected fid pos\n",
+            $self->{fid}[$i_fid]
+            )
           unless ($fid_ok[$i_fid]);
     }
 }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1955,7 +1955,7 @@ sub check_fids {
         }
         my $fidsel_ok = 0;
 
-        my $offsets = call_python("utils._get_fid_offset",
+        my $offsets = call_python("utils.get_fid_offset",
             [ $self->{date}, $self->{ccd_temp_acq} ]);
         my $dy = $offsets->[0];
         my $dz = $offsets->[1];

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1919,19 +1919,19 @@ sub get_fid_positions{
 
     my $self = shift;
     my $c = shift;
-    my $fid_positions = [];
+    my @fid_positions;
 
     # If no star cat fids and no commanded fids, then return
-    return $fid_positions if (@{ $self->{fid} } == 0 && @{ $self->{fidsel} } == 0);
+    return \@fid_positions if (@{ $self->{fid} } == 0 && @{ $self->{fidsel} } == 0);
 
     # Make sure we have SI and SIM_OFFSET_Z to be able to calculate fid yang and zang
     unless (defined $self->{SI}) {
         push @{$self->{warn}}, "Unable to check fids because SI undefined\n";
-        return $fid_positions;
+        return \@fid_positions;
     }
     unless (defined $self->{SIM_OFFSET_Z}) {
         push @{$self->{warn}}, "Unable to check fids because SIM_OFFSET_Z undefined\n";
-        return $fid_positions;
+        return \@fid_positions;
     }
 
     # For each FIDSEL fid, calculate position
@@ -1951,9 +1951,9 @@ sub get_fid_positions{
         $yag += $dy;
         $zag += $dz;
 
-        push @{$fid_positions}, { y => $yag, z => $zag };
+        push @fid_positions, { y => $yag, z => $zag };
     }
-    return $fid_positions;
+    return \@fid_positions;
 
 }
 

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -1,7 +1,4 @@
-import pytest
-import numpy as np
 from starcheck.utils import check_hot_pix
-from starcheck.utils import _get_fid_offset
 
 
 def test_check_dynamic_hot_pix():
@@ -69,38 +66,3 @@ def test_check_dynamic_hot_pix():
             assert imposter1["bad2_mag"] < imposter2["bad2_mag"]
             assert imposter1["offset"] > imposter2["offset"]
 
-
-def test_get_fid_offset(monkeypatch):
-    # Test case 1: enable_fid_offset_env is True
-    with monkeypatch.context() as m:
-        m.setenv("PROSECO_ENABLE_FID_OFFSET", "True")
-        date = "2023:200"
-        t_ccd_acq = -5.0
-        expected_dy = -0.36
-        expected_dz = -5.81
-        dy, dz = _get_fid_offset(date, t_ccd_acq)
-        assert np.isclose(dy, expected_dy, atol=0.1, rtol=0)
-        assert np.isclose(dz, expected_dz, atol=0.1, rtol=0)
-
-    # Test case 2: enable_fid_offset_env is False
-    with monkeypatch.context() as m:
-        m.setenv("PROSECO_ENABLE_FID_OFFSET", "False")
-        date = "2023:200"
-        t_ccd_acq = -5.0
-        expected_dy = 0.0
-        expected_dz = 0.0
-        dy, dz = _get_fid_offset(date, t_ccd_acq)
-        assert dy == expected_dy
-        assert dz == expected_dz
-
-    # Test case 3: enable_fid_offset_env is invalid
-    with monkeypatch.context() as m:
-        m.setenv("PROSECO_ENABLE_FID_OFFSET", "invalid")
-        date = "2023:200"
-        t_ccd_acq = -5.0
-        with pytest.raises(ValueError) as e:
-            _get_fid_offset(date, t_ccd_acq)
-        assert (
-            str(e.value)
-            == 'PROSECO_ENABLE_FID_OFFSET env var must be either "True" or "False" got invalid'
-        )

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -1,4 +1,7 @@
+import pytest
+import numpy as np
 from starcheck.utils import check_hot_pix
+from starcheck.utils import _get_fid_offset
 
 
 def test_check_dynamic_hot_pix():
@@ -62,7 +65,42 @@ def test_check_dynamic_hot_pix():
             assert imposter1["bad2_mag"] == imposter2["bad2_mag"]
             assert imposter1["offset"] == imposter2["offset"]
         else:
-            assert imposter2["t_ccd"] == imposter1["t_ccd"] - dyn_bgd_dt_ccd        
+            assert imposter2["t_ccd"] == imposter1["t_ccd"] - dyn_bgd_dt_ccd
             assert imposter1["bad2_mag"] < imposter2["bad2_mag"]
             assert imposter1["offset"] > imposter2["offset"]
-        
+
+
+def test_get_fid_offset(monkeypatch):
+    # Test case 1: enable_fid_offset_env is True
+    with monkeypatch.context() as m:
+        m.setenv("PROSECO_ENABLE_FID_OFFSET", "True")
+        date = "2023:200"
+        t_ccd_acq = -5.0
+        expected_dy = -0.36
+        expected_dz = -5.81
+        dy, dz = _get_fid_offset(date, t_ccd_acq)
+        assert np.isclose(dy, expected_dy, atol=0.1, rtol=0)
+        assert np.isclose(dz, expected_dz, atol=0.1, rtol=0)
+
+    # Test case 2: enable_fid_offset_env is False
+    with monkeypatch.context() as m:
+        m.setenv("PROSECO_ENABLE_FID_OFFSET", "False")
+        date = "2023:200"
+        t_ccd_acq = -5.0
+        expected_dy = 0.0
+        expected_dz = 0.0
+        dy, dz = _get_fid_offset(date, t_ccd_acq)
+        assert dy == expected_dy
+        assert dz == expected_dz
+
+    # Test case 3: enable_fid_offset_env is invalid
+    with monkeypatch.context() as m:
+        m.setenv("PROSECO_ENABLE_FID_OFFSET", "invalid")
+        date = "2023:200"
+        t_ccd_acq = -5.0
+        with pytest.raises(ValueError) as e:
+            _get_fid_offset(date, t_ccd_acq)
+        assert (
+            str(e.value)
+            == 'PROSECO_ENABLE_FID_OFFSET env var must be either "True" or "False" got invalid'
+        )

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -14,7 +14,7 @@ from Chandra.Time import DateTime
 from chandra_aca.star_probs import mag_for_p_acq
 import chandra_aca.star_probs
 from chandra_aca.dark_model import dark_temp_scale
-import chandra_aca.drift
+from chandra_aca.drift import get_fid_offset
 import sparkles
 from chandra_aca.transform import mag_to_count_rate, pixels_to_yagzag, yagzag_to_pixels
 from kadi.commands import states
@@ -138,23 +138,6 @@ def get_dither_kadi_state(date):
         np.max([DateTime(state["__dates__"][key]).secs for key in cols])
     )
     return state
-
-
-def _get_fid_offset(date, t_ccd_acq):
-    dy, dz = (0, 0)
-
-    enable_fid_offset_env = os.environ.get("PROSECO_ENABLE_FID_OFFSET", "True")
-    if enable_fid_offset_env not in ("True", "False"):
-        raise ValueError(
-            f'PROSECO_ENABLE_FID_OFFSET env var must be either "True" or "False" '
-            f"got {enable_fid_offset_env}"
-        )
-
-    # The env var is still just a string so do a string equals on it
-    if enable_fid_offset_env == "True":
-        dy, dz = chandra_aca.drift.get_fid_offset(date, t_ccd_acq)
-
-    return float(dy), float(dz)
 
 
 def get_run_start_time(run_start_time, backstop_start):

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -141,7 +141,6 @@ def get_dither_kadi_state(date):
 
 
 def _get_fid_offset(date, t_ccd_acq):
-
     dy, dz = (0, 0)
 
     enable_fid_offset_env = os.environ.get("PROSECO_ENABLE_FID_OFFSET", "True")


### PR DESCRIPTION
## Description

Moves "expected" position of fid lights to be their positions with chandra_aca.drift.get_fid_offset applied.

The expected positions are used to check if there is a commanded ON fid light within fid-light-search-hw of th expected position and to check if there is a fid light in an acquisition box

This also removes < -14C warning (which was a proxy for fid position).  

## Interface impacts

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Output in https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr431/

sandbox_starcheck run out of ska3-masters

``` 
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2122/oflsa/ -out nov2122a_25hw # with 25hw box artificially set on Obsid.pm
/home/jeanconn/git/starcheck/sandbox_starcheck -dir /data/mpcrit1/mplogs/2022/NOV2122/oflsa/ -out nov2122a_40hw # with 40hw box (PR value)
/proj/sot/ska3/flight/bin/skare starcheck -dir /data/mpcrit1/mplogs/2022/NOV2122/oflsa/ -out nov2122a_flight
diff nov2122a_40hw.txt nov2122a_flight.txt > nov2122a_diff.txt
/proj/sot/ska/bin/diff2html nov2122a_flight.txt nov2122a_40hw.txt > nov2122a_diff.html
```


