### PR TITLE
Update High IR Zone check to -25 +27 around perigee

### DIFF
--- a/starcheck/check_ir_zone.py
+++ b/starcheck/check_ir_zone.py
@@ -29,9 +29,9 @@ def ir_zone_ok(backstop_file, out=None):
     out_text = ["IR ZONE CHECKING"]
     for perigee_time in perigee_cmds['time']:
 
-        # Current high ir zone is from 30 minutes before to 20 minutes after
-        ir_zone_start = perigee_time - 30 * 60
-        ir_zone_stop = perigee_time + 20 * 60
+        # Current high ir zone is from 25 minutes before to 27 minutes after
+        ir_zone_start = perigee_time - 25 * 60
+        ir_zone_stop = perigee_time + 27 * 60
         out_text.append(
             f"Checking perigee at {CxoTime(perigee_time).date}")
         out_text.append(


### PR DESCRIPTION
## Description

Update High IR Zone to -25 +27 around perigee

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
I tested and ran this out of a ska3-masters (though I've forgotten where things are with what is in HEAD ska3-flight and https://github.com/sot/starcheck/pull/430 in master).  Because this NMM check is really a PCAD check and the starcheck check is complementary, I don't think we need a patch/branch release for this off of starcheck 14.4.0.

As Javier noted in comments the test dependence in ska3-masters turned out to be hopper with https://github.com/sot/hopper/pull/25 .

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Javier
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functionally, I just ran this on OCT2823A at

https://icxc.cfa.harvard.edu/aspect/SFE/2023/OCT2823/oflsa/starcheck.html 

and quickly confirmed the times in the high ir zone report compared to the flight output at 

https://icxc.harvard.edu/mp/mplogs/2023/OCT2823/oflsa/starcheck.html
