### PR TITLE
Remove maneuver error 

### DIFF
--- a/starcheck/parser.py
+++ b/starcheck/parser.py
@@ -177,13 +177,12 @@ def get_manvrs(obs_text):
                                        target_Q3=float(quat_re.group(3)),
                                        target_Q4=float(quat_re.group(4))))
             angle_re = re.match(
-                "\s+MANVR: Angle=\s+(\d+\.\d+)\sdeg\s+Duration=\s+(\d+)\ssec\s+Slew\serr=\s+(\d+\.\d)\sarcsec(\s+End=\s+(\S+))?",
+                "\s+MANVR: Angle=\s+(\d+\.\d+)\sdeg\s+Duration=\s+(\d+)\ssec(\s+Slew\serr=\s+(\d+\.\d)\sarcsec)?(\s+End=\s+(\S+))?",
                 mline)
             if angle_re:
                 curr_manvr.update(dict(angle_deg=float(angle_re.group(1)),
-                                       duration_sec=int(angle_re.group(2)),
-                                       slew_err_arcsec=float(angle_re.group(3)),
-                                       end_date=angle_re.group(5)))
+                                       duration_sec=int(angle_re.group(2)),,
+                                       end_date=angle_re.groups()[-1]))
                 if 'target_Q1' not in curr_manvr:
                     raise ValueError("No Q1,Q2,Q3,Q4 line found when parsing starcheck.txt")
         # If there is a real manvr, append to list

--- a/starcheck/parser.py
+++ b/starcheck/parser.py
@@ -181,7 +181,7 @@ def get_manvrs(obs_text):
                 mline)
             if angle_re:
                 curr_manvr.update(dict(angle_deg=float(angle_re.group(1)),
-                                       duration_sec=int(angle_re.group(2)),,
+                                       duration_sec=int(angle_re.group(2)),
                                        end_date=angle_re.groups()[-1]))
                 if 'target_Q1' not in curr_manvr:
                     raise ValueError("No Q1,Q2,Q3,Q4 line found when parsing starcheck.txt")

--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -234,12 +234,8 @@ Checks
 |ACA-021|ACA field-of-view |X|X|FL: Z at least half-width inside           |n/a |Reduced aspect  |
 |       |limits            | | |field-of-view limits                       |    |quality         |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
-|       |                  | | |AS: Impact of spoilers on acquisition      |    |                |
-|       |                  | | |probability is calculated in proseco.      |    |                |
-|ACA-022|Spoiler stars     |X|X|Previously this was handled as a red warn  |n/a |Possible Bright |
-|       |                  | | |for AS spoiled by another object brighter  |    |Star Hold       |
-|       |                  | | |than mag(AS) + 0.2, that lies closer than  |    |                |
-|       |                  | | |maneuver uncertainty to the AS search box. |    |                |
+|ACA-022|Spoiler stars     |X|X|AS: Impact of acquisition spoilers included|n/a |Possible Bright |
+|       |                  | | |in acquisition probability calculation     |    |Star Hold       |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
 |       |                  |X|X|GS: spoiled by another object brighter than|    |Reduced aspect  |
 |ACA-023|Spoiler stars     | | |mag(GS) + 0.2, that lies closer than       |n/a |quality         |

--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -6,9 +6,9 @@ ACA Load Review Checklist
    file in the starcheck git project
 
 
-Date: 2022-Oct-26
+Date: 2024-Jan-17
 
-Version: 3.9
+Version: 3.10
 
 Author: E. Martin, S. Hurley, T. Aldcroft, J. Connelly, J. Gonzalez
 
@@ -52,8 +52,6 @@ Load Input Files
   - Dither: ./History/DITHER.txt
 
   - Radmon: ./History/RADMON.txt
-
-  - Maneuver Error: ./output/MMMddyyv_ManErr.txt
 
   - Processing Summ: ./mps/msddd:hhvv.sum
 
@@ -236,9 +234,12 @@ Checks
 |ACA-021|ACA field-of-view |X|X|FL: Z at least half-width inside           |n/a |Reduced aspect  |
 |       |limits            | | |field-of-view limits                       |    |quality         |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
-|       |                  |X|X|AS: spoiled by another object brighter than|    |Possible Bright |
-|ACA-022|Spoiler stars     | | |mag(AS) + 0.2, that lies closer than       |n/a |Star Hold       |
-|       |                  | | |maneuver uncertainty to the AS search box  |    |                |
+|       |                  | | |AS: Impact of spoilers on acquisition      |    |                |
+|       |                  | | |probability is calculated in proseco.      |    |                |
+|ACA-022|Spoiler stars     |X|X|Previously this was handled as a red warn  |n/a |Possible Bright |
+|       |                  | | |for AS spoiled by another object brighter  |    |Star Hold       |
+|       |                  | | |than mag(AS) + 0.2, that lies closer than  |    |                |
+|       |                  | | |maneuver uncertainty to the AS search box. |    |                |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
 |       |                  |X|X|GS: spoiled by another object brighter than|    |Reduced aspect  |
 |ACA-023|Spoiler stars     | | |mag(GS) + 0.2, that lies closer than       |n/a |quality         |

--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -409,55 +409,6 @@ sub get_fid_actions {
     return (\@action, \@time, $fid_time_violation);
 }
 
-#AXMAN Run at 03/25/2002 08:57:09  Version of Mar-12-2002
-#
-#Man File = C:\wsdavis\CXOFiles\MPS_Sched_Chk\APR0102A\md091_0405.dot.man
-#Calib File 1 = C:\wsdavis\CXOFiles\ManError\GYRO_OAC.mat
-#Calib File 2 = C:\wsdavis\CXOFiles\ManError\GYROTotalCal.mat
-#SBoxMargin =    20.00 asec, 3-sig init roll uncer =    30.00 asec
-# obsid MaxErrYZ Seg start_time        stop_time         ssss    angle    X-axis    Y-axis    Z-axis     initQ1      initQ2      initQ3      initQ4       finalQ1     finalQ2     finalQ3     finalQ4     iru-X    iru-Y    iru-Z     aber-X   aber-Y   aber-Z  del-Y    del-Z    delYZ   iruadjYZ totadjYZ syserr.Y syserr.Z ranerr.Y ranerr.Z
-#  2193    59.43  0  2002:091:04:50:16 2002:091:05:09:04 ----   35.531 -0.425054 -0.486987  0.763003   0.85686666 -0.10606580 -0.34000709  0.37272612   0.69244839 -0.31178304 -0.37809776  0.52947960   -21.34     8.07    20.98     4.11     5.37    -8.15     0.00     0.00     0.00    22.48    29.25     2.70    29.13    12.15    10.31
-#  1664    87.62  0  2002:091:10:59:56 2002:091:11:27:23 ----   74.053  0.113094 -0.877861  0.465370   0.69244839 -0.31178304 -0.37809776  0.52947960   0.30163013 -0.74861636 -0.49829514  0.31669350   -30.97    23.87    28.00     5.67    16.14   -15.44     0.00    -0.00     0.00    36.79    44.12     7.73    43.44    15.59    24.18
-#total number of maneuvers = 27
-#----      5
-#---+      1
-###############################################################
-sub man_err {
-###############################################################
-    my $man_err = shift;
-    my $in_man = 0;
-    my @me = ();
-    my @cols;
-    open(my $MANERR, $man_err)
-      or die "Couldn't open maneuver error file $man_err for reading\n";
-    while (<$MANERR>) {
-        chomp;
-        last if (/total number/i);
-        next unless (/\S/);
-        next if (/#Schedule generated/);
-        if ($in_man) {
-            my @vals = split;
-            if ($#vals != $#cols) {
-                warn "man_err: ERROR - mismatch between column names and data values\n";
-                return ();    # return nothing
-            }
-            my %data = map { $cols[$_], $vals[$_] } (0 .. $#cols);
-            $data{Seg} = 1
-              if ($data{Seg} == 0)
-              ;    # Make it easier later on to match the segment number
-                   # with the MP_TARGQUAT commands
-            $data{obsid} = sprintf "%d", $data{obsid};    # Clip leading zeros
-
-            push @me, \%data;
-        }
-        if (/^\s*obsid\s+maxerryz\s+seg/i) {
-            @cols = split;
-            $in_man = 1;
-        }
-    }
-    close $MANERR;
-    return @me;
-}
 
 ###############################################################
 sub backstop {

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -192,7 +192,6 @@ my $odb_file = get_file("$Starcheck_Data/$par{fid_char}*", 'odb', 'required');
 
 my $agasc_file = get_file("$par{agasc_file}", "agasc_file");
 
-my $manerr_file = get_file("$par{dir}/output/*_ManErr.txt", 'manerr');
 my $ps_file = get_file("$par{dir}/mps/ms*.sum", 'processing summary');
 my $tlr_file = get_file("$par{dir}/${sosa_dir_slash}*.tlr", 'TLR', 'required');
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -335,13 +335,6 @@ Ska::Starcheck::Obsid::setcolors(
 my %odb = Ska::Parse_CM_File::odb($odb_file);
 Ska::Starcheck::Obsid::set_odb(%odb);
 
-# Read Maneuver error file containing more accurate maneuver errors
-print "Reading Maneuver Error file $manerr_file\n";
-my @manerr;
-if ($manerr_file) {
-    @manerr = Ska::Parse_CM_File::man_err($manerr_file);
-}
-else { warning("Could not find Maneuver Error file in output/ directory\n") }
 
 # Get an initial dither state from kadi.  Dither states are then built from backstop commands
 # after this time.  If the running loads will be terminated in advance of new commands in the loads
@@ -454,7 +447,6 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->set_target();
     $obs{$obsid}->set_star_catalog();
     $obs{$obsid}->set_maneuver($mm);
-    $obs{$obsid}->set_manerr(@manerr) if (@manerr);
     $obs{$obsid}->set_files(
         $STARCHECK,
         $backstop,


### PR DESCRIPTION
## Description

Remove maneuver error file parsing and use in load review.

The acquisition star search spoiler check is also removed (though appears to be incorrectly labeled ACA-023 in starcheck).  The warning based on one maneuver error estimate is no longer relevant with proseco's probability of acquisition based on a variety of factors including spoiler stars and imposters.  This PR updates the checklist to indicate this.

Update starcheck_parser to handle starcheck.txt without maneuver error and stop archiving maneuver error in starcheck database.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->


## Interface impacts
Newly "ingested" starcheck outputs into mica database will not have slew_err_arcsec populated.

This PR includes an update to the ACA checklist.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

```
(ska3) flame:starcheck jean$ git rev-parse HEAD
1ed197514e886db2cbbd7a262e9808d93fdb6247
(ska3) flame:starcheck jean$ pytest
======================================================================= test session starts ========================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jean/git/starcheck
plugins: timeout-2.1.0, anyio-3.6.2
collected 14 items                                                                                                                                                 

starcheck/tests/test_state_checks.py .............                                                                                                           [ 92%]
starcheck/tests/test_utils.py .                                                                                                                              [100%]

========================================================================= warnings summary =========================================================================
../../miniconda3/envs/ska3/lib/python3.10/site-packages/jupyter_client/connect.py:27
  /Users/jean/miniconda3/envs/ska3/lib/python3.10/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 14 passed, 1 warning in 5.34s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Several recent load weeks run.  Output and diffs relative to master at [https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr436/](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr436/combined_diff.txt) .  Diffs show expected changes:

1. Warning about mismatch target quaternion removed.
2. Acquisition spoiler warnings removed
3. Output does not have slew error in text for every maneuver

I ran functional testing at 1ed1975 and did not rerun for the small additional change in c4e7caf, though I did do a quick run-test of sandbox_starcheck to confirm that c4e7caf did not introduce any format errors.

For functional testing of the starcheck parser, I confirmed that it reads old and new starcheck.txt files with no errors and does not include slew_err_arcsec.

```
Using the version of starcheck.parser in this PR
In [17]: test = starcheck.parser.read_starcheck('/proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/starcheck/starcheck
    ...: -pr436/JAN1524b_test.txt')

In [18]: master = starcheck.parser.read_starcheck('/proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/starcheck/starche
    ...: ck-pr436/JAN1524b_master.txt')

In [19]: test[0]['manvrs']
Out[19]: 
[{'mp_targquat_time': '2024:015:01:49:40.614',
  'mp_targquat_vcdu_cnt': 11256884,
  'target_Q1': -0.13912334,
  'target_Q2': -0.61804467,
  'target_Q3': -0.75670549,
  'target_Q4': 0.16143815,
  'angle_deg': 71.81,
  'duration_sec': 1617,
  'end_date': '2024:015:02:16:43',
  'instance': 0}]

In [20]: master[0]['manvrs']
Out[20]: 
[{'mp_targquat_time': '2024:015:01:49:40.614',
  'mp_targquat_vcdu_cnt': 11256884,
  'target_Q1': -0.13912334,
  'target_Q2': -0.61804467,
  'target_Q3': -0.75670549,
  'target_Q4': 0.16143815,
  'angle_deg': 71.81,
  'duration_sec': 1617,
  'end_date': '2024:015:02:16:43',
  'instance': 0}]
```

This compares with this behavior in master which just skips parsing the *other* maneuver details if there is no slew error recorded in the starcheck output
```
In [2]: test = starcheck.parser.read_starcheck('/proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/starcheck/starcheck-
   ...: pr436/JAN1524b_test.txt')

In [4]: test[0]['manvrs'][0]
Out[4]: 
{'mp_targquat_time': '2024:015:01:49:40.614',
 'mp_targquat_vcdu_cnt': 11256884,
 'target_Q1': -0.13912334,
 'target_Q2': -0.61804467,
 'target_Q3': -0.75670549,
 'target_Q4': 0.16143815,
 'instance': 0}

In [5]: master = starcheck.parser.read_starcheck('/proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/starcheck/starchec
   ...: k-pr436/JAN1524b_master.txt')

In [6]: master[0]['manvrs']
Out[6]: 
[{'mp_targquat_time': '2024:015:01:49:40.614',
  'mp_targquat_vcdu_cnt': 11256884,
  'target_Q1': -0.13912334,
  'target_Q2': -0.61804467,
  'target_Q3': -0.75670549,
  'target_Q4': 0.16143815,
  'angle_deg': 71.81,
  'duration_sec': 1617,
  'slew_err_arcsec': 46.9,
  'end_date': '2024:015:02:16:43',
  'instance': 0}]
```

It isn't a perfect test of the integration of this with the mica starcheck processing, but I also use a snapshot of the mica starcheck db and had it run it's update process with this PR starcheck.parser in PYTHONPATH.  That confirms that inserting new rows into the maneuver table without slew_err_arcsec should not be a problem.  From mica git repo ...


Spot checked an obsid
```
sqlite3 /proj/sot/.snapshot/weekly.2024-01-21_0015/ska/data/mica/archive/starcheck/starcheck.db3
sqlite> select obsid,slew_err_arcsec from starcheck_manvr where obsid = 29217;
29217|68.0
sqlite>
```

Ran update
```
ska3-jeanconn-fido> export PYTHONPATH=/home/jeanconn/git/starcheck
ska3-jeanconn-fido> mkdir -p mica_archive/starcheck
ska3-jeanconn-fido> cp /proj/sot/.snapshot/weekly.2024-01-21_0015/ska/data/mica/archive/starcheck/starcheck* mica_archive/starcheck/
ska3-jeanconn-fido> export MICA_ARCHIVE=/home/jeanconn/git/mica/mica_archive/
ska3-jeanconn-fido> python /proj/sot/ska3/flight/share/mica/update_starchecks.py 
Getting new starcheck.txt files from /data/mpcrit1/mplogs
Attempting ingest of /data/mpcrit1/mplogs/2024/JAN2224/oflsa/starcheck.txt
Attempting ingest of /data/mpcrit1/mplogs/2024/JAN2324/oflsb/starcheck.txt
Attempting ingest of /data/mpcrit1/mplogs/2024/JAN2324/oflsa/starcheck.txt
Attempting ingest of /data/mpcrit1/mplogs/2024/JAN2624/oflsa/starcheck.txt
Attempting ingest of /data/mpcrit1/mplogs/2024/JAN2924/oflsa/starcheck.txt
Attempting ingest of /data/mpcrit1/mplogs/2024/FEB0524/oflsa/starcheck.txt

```
I note that JAN2224A was already in the database with the 29217 obsid.  The job finished without error and I rechecked 29217 (which also appeared in the JAN2324 and JAN2624 schedules).

```
sqlite> select obsid,slew_err_arcsec from starcheck_manvr  where obsid=29217;
29217|68.0
29217|
29217|
29217|
sqlite> select * from starcheck_manvr  where obsid=29217;
2532|29217|58|0|1766.0|82.94|68.0|0.00412132|-0.14894917|0.87225855|0.46579199|2024:028:22:01:12.278|15923778|2024:028:22:30:44
2533|29217|43|0|1766.0|82.94||0.00412132|-0.14894917|0.87225856|0.46579197|2024:028:22:01:12.278|15923778|2024:028:22:30:44
2534|29217|43|0|1766.0|82.94||0.00412132|-0.14894917|0.87225856|0.46579197|2024:028:22:01:12.278|15923778|2024:028:22:30:44
2535|29217|20|0|2060.0|105.0||-0.01619077|-0.18685837|0.86492329|0.46554217|2024:028:20:43:26.947|15905572|2024:028:21:17:52
sqlite> select sc_id,slew_err_arcsec from starcheck_manvr  where obsid=29217;
2532|68.0
2533|
2534|
2535|
sqlite> select * from starcheck_id where id = 2532;
2532|/2024/JAN2224/oflsa/|1705513689.59542
sqlite> select * from starcheck_id where id = 2533;
2533|/2024/JAN2324/oflsb/|1705969630.04826
sqlite> select * from starcheck_id where id = 2534;
2534|/2024/JAN2324/oflsa/|1705970179.81214
sqlite> select * from starcheck_id where id = 2535;
2535|/2024/JAN2624/oflsa/|1706221645.05288
```
