### PR TITLE
Remove some useless ACQ star warnings

### DIFF
--- a/starcheck/src/aca_load_review_cl.rst
+++ b/starcheck/src/aca_load_review_cl.rst
@@ -302,10 +302,7 @@ Checks
 |ACA-040|Monitor commanding|X|X|Dither is disabled and enabled with correct|n/a |Failure to track|
 |       |                  | | |timing                                     |    |                |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+
-|       |                  |X|X|                                           |    |AS: Reduced     |
-|       |                  | | |                                           |    |acq probability |
-|       |                  | | |                                           |    |of star         |
-|ACA-041|Magnitude         | | |Slot MAXMAG (faint limit) - star MAG >= 0.3|n/a |GS: Increased   |
+|ACA-041|Magnitude         |X|X|Slot MAXMAG (faint limit) - star MAG >= 0.3|n/a |GS: Increased   |
 |       |                  | | |                                           |    |risk of loss of |
 |       |                  | | |                                           |    |track of star   |
 +-------+------------------+-+-+-------------------------------------------+----+----------------+

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1480,9 +1480,7 @@ sub check_star_catalog {
             push @orange_warn, sprintf "[%2d] Acq Off (padded) CCD by > 60 arcsec.\n",
               $i;
         }
-        elsif (($type =~ /BOT|ACQ/) and ($acq_edge_delta < 0)) {
-            push @{ $self->{fyi} }, sprintf "[%2d] Acq Off (padded) CCD\n", $i;
-        }
+
 
         # Faint and bright limits ~ACA-009 ACA-010
         if ($mag ne '---') {
@@ -1498,12 +1496,6 @@ sub check_star_catalog {
                   $mag;
                 if ($mag < 5.2) {
                     push @warn, $acq_mag_warn;
-                }
-                elsif ($mag > $self->{mag_faint_red}) {
-                    push @orange_warn, $acq_mag_warn;
-                }
-                elsif ($mag > $self->{mag_faint_yellow}) {
-                    push @yellow_warn, $acq_mag_warn;
                 }
             }
         }
@@ -1541,7 +1533,7 @@ sub check_star_catalog {
             }
         }
 
-        if ($type =~ /BOT|GUI|ACQ/) {
+        if ($type =~ /BOT|GUI/) {
             if (($maxmag =~ /---/) or ($mag =~ /---/)) {
                 push @warn, sprintf "[%2d] Magnitude.  MAG or MAGMAX not defined \n",
                   $i;


### PR DESCRIPTION
## Description

Remove some warnings on acquisition stars.  These per-star warnings are no longer relevant as they are issues that are included in the proseco calculation of acquisition probability.

Remove 
1.  "Magnitude. Acq star" warnings for acq stars fainter than red or yellow (calculated) mag limits
2.  "Acq Off (padded) CCD" warning

These warnings will be removed for ACQ-only stars but continue for BOT 
1.  "Magnitude.  MAXMAG - MAG < 0.3" 
2. "Magnitude.  MAXMAG %.2f not within 0.1 mag of %.2f" (for maxmag not close to expected value)

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #434

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
(ska3-masters) jeanconn-fido> git rev-parse HEAD
ca4812dca4e2b459ed7291c8f03e846c1416a846
(ska3-masters) jeanconn-fido> pytest
======================================================================= test session starts ========================================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git/starcheck
plugins: timeout-2.1.0, anyio-3.6.2
collected 1 item                                                                                                                                                   

starcheck/tests/test_utils.py .                                                                                                                              [100%]

========================================================================= warnings summary =========================================================================
../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21
../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_forbids_neg_powint = LooseVersion(numpy.__version__) >= LooseVersion('1.12.0b1')

../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/jupyter_client/connect.py:27
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 1 passed, 3 warnings in 32.56s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Several recent load weeks run.  Output and diffs relative to master at [https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr437/](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr437/combined_diff.txt) .  Diffs show expected changes.
