### PR TITLE
Use Python to make text report from html

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -33,7 +33,6 @@ use JSON ();
 
 use Cwd qw( abs_path );
 
-use HTML::TableExtract;
 use Carp 'verbose';
 $SIG{__DIE__} = sub { Carp::confess(@_) };
 
@@ -965,41 +964,10 @@ qq{<BODY><div id="overDiv" style="position:absolute; visibility:hidden; z-index:
 
 if ($par{text}) {
 
+
     my $textout = io("${STARCHECK}.txt");
-
-    my $te = HTML::TableExtract->new();
-    $te->parse($out);
-
-    my %table;
-    foreach my $ts ($te->table_states) {
-
-        #	print "Table (", join(',', $ts->coords), "):\n";
-        my $table_text = qq{};
-        my ($depth, $count) = $ts->coords;
-        foreach my $row ($ts->rows) {
-            $table_text .= $row->[0] . "\n" if defined $row->[0];
-        }
-        if ($table_text =~ /OBSID/s) {
-            $table{$depth}{$count} = $table_text;
-        }
-    }
-
-    #    use Data::Dumper;
-    #    print Dumper %table;
-    for my $depth (sort { $a <=> $b } (keys %table)) {
-        for my $count (sort { $a <=> $b } (keys %{ $table{$depth} })) {
-
-            #	    print " $depth $count \n";
-            my $chunk = $table{$depth}{$count};
-            chomp($chunk);
-            $chunk =~ s/\s+$/\n/;
-            $textout->print("$chunk");
-            $textout->print(
-"==================================================================================== \n"
-            );
-        }
-    }
-
+    $textout->print(call_python("utils.prehtml2text", [ $out ]));
+    $textout->close;
     print STDERR "Wrote text report to $STARCHECK.txt\n";
 
 }

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 from pathlib import Path
 import warnings
+from bs4 import BeautifulSoup
 
 import agasc
 import cxotime
@@ -44,6 +45,21 @@ warnings.filterwarnings(
     category=UserWarning,
     message=r"\nModel .* computed between .* clipping input mag\(s\) outside that range\.",
 )
+
+def prehtml2text(html_text):
+    """Convert the starcheck report html to plain text."""
+
+    soup = BeautifulSoup(html_text, "lxml")
+
+    # All of the report is basically in the pre tags
+    pres = list(soup.find_all("pre"))
+    out = []
+    for pre in pres:
+        out.append(pre.get_text())
+        # And include a line of equals to separate the sections
+        out.append("=" * 84)
+
+    return "\n".join(out)
 
 
 def date2secs(val):


### PR DESCRIPTION
## Description

Use Python to make text report from html

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This is intended to support our arm64 build, as I have not quite gotten Perl HTML::TableExtract to build successfully on arm64 and perhaps we just don't need it.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2024.1rc4) flame:starcheck jean$ pytest
================================================ test session starts ================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 14 items                                                                                                  

starcheck/tests/test_state_checks.py .............                                                            [ 92%]
starcheck/tests/test_utils.py .                                                                               [100%]

================================================= warnings summary ==================================================
../../miniconda3/envs/ska3-flight-2024.1rc4/lib/python3.11/site-packages/tables/node.py:251
../../miniconda3/envs/ska3-flight-2024.1rc4/lib/python3.11/site-packages/tables/node.py:251
starcheck/starcheck/tests/test_state_checks.py::test_get_obs_man_angle[646940289.224-143.4]
  /Users/jean/miniconda3/envs/ska3-flight-2024.1rc4/lib/python3.11/site-packages/tables/node.py:251: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    self._v_objectid = self._g_open()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== 14 passed, 3 warnings in 7.76s ===========================================
(ska3-flight-2024.1rc4) flame:starcheck jean$ git rev-parse HEAD
a9edae5f73b558b0df4230cb5bf33edabc860786
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This needs regression review with the starcheck_parser .
