### PR TITLE
Round CCD temperature for check and add 3-digit max T_CCD output

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2407,7 +2407,11 @@ sub print_report {
             $o .= "\n";
         }
 
-        $o .= sprintf("Predicted Max CCD temperature: %.1f C ", $self->{ccd_temp});
+        $o .= sprintf(
+            "Predicted Max CCD temperature: %.1f C (%.3f C)",
+            $self->{ccd_temp},
+            $self->{ccd_temp}
+        );
         if (defined $self->{n100_warm_frac}) {
             $o .= sprintf("\t N100 Warm Pix Frac %.3f", $self->{n100_warm_frac});
         }
@@ -2857,10 +2861,13 @@ sub set_ccd_temps {
     $self->{ccd_temp_acq} = $obsid_temps->{ $self->{obsid} }->{ccd_temp_acq};
     $self->{n100_warm_frac} = $obsid_temps->{ $self->{obsid} }->{n100_warm_frac};
 
-    # Add critical warning for ACA planning limit violation
-    if ($self->{ccd_temp} > $config{ccd_temp_red_limit}) {
+    # Add critical warning for ACA planning limit violation. Round both the temperature
+    # and the limit to 1 decimal place for comparison.
+    my $ccd_temp_round = sprintf("%.1f", $self->{ccd_temp});
+    my $ccd_temp_red_limit_round = sprintf("%.1f", $config{ccd_temp_red_limit});
+    if ($ccd_temp_round > $ccd_temp_red_limit_round) {
         push @{ $self->{warn} },
-          sprintf("CCD temperature exceeds %.1f C\n", $config{ccd_temp_red_limit});
+          sprintf("CCD temperature exceeds %.1f C\n", $ccd_temp_red_limit_round);
     }
 
     # Add info for having a penalty temperature too


### PR DESCRIPTION
## Description

Changes:

- Round the max CCD temperature and the limit to one decimal place for checking.
- Print max CCD temperature to 3 digits for diagnostics

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Changes starcheck notes format to add a 3-digit output of the max CCD temperature for diagnostics. No impact to parsing (see functional test below).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests

```
ska3-jeanconn-fido> pytest
=================================================== test session starts ====================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 14 items                                                                                                         

starcheck/tests/test_state_checks.py .............                                                                   [ 92%]
starcheck/tests/test_utils.py .                                                                                      [100%]

=================================================== 14 passed in 57.27s
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
The JUL0824A products showed a critical warning for obsid 26575
#### Flight (notes for 26575)
```
>> CRITICAL: CCD temperature exceeds -3.9 C

Probability of acquiring 2 or fewer stars (10^-x):	7.9	
Acquisition Stars Expected  : 7.77
Guide star count: 5.0 	
Predicted Max CCD temperature: -3.9 C 	 N100 Warm Pix Frac 0.498
Dynamic Mag Limits: Yellow 9.76 	 Red 10.08
```
#### Patch (notes for 26575)
```
$ ./sandbox_starcheck -dir /Users/aldcroft/ska/data/mpcrit1/mplogs/2024/JUL0824/oflsa -out jul0824
...
Probability of acquiring 2 or fewer stars (10^-x):	7.9	
Acquisition Stars Expected  : 7.77
Guide star count: 5.0 	
Predicted Max CCD temperature: -3.9 C (-3.892 C)	 N100 Warm Pix Frac 0.498
Dynamic Mag Limits: Yellow 9.76 	 Red 10.08
```
As expected, all other obsids showed the new 3-digit representation of the max CCD temperature.

#### Patch with temporary code to force a violation in 26575
Patched one code line as follows, adding 0.1 to the computed CCD temperature:
```
    my $ccd_temp_round = sprintf("%.1f", $self->{ccd_temp} + 0.1);
```
This gave:
```
>> CRITICAL: CCD temperature exceeds -3.9 C

Probability of acquiring 2 or fewer stars (10^-x):	7.9	
Acquisition Stars Expected  : 7.77
Guide star count: 5.0 	
Predicted Max CCD temperature: -3.9 C (-3.892 C)	 N100 Warm Pix Frac 0.498
Dynamic Mag Limits: Yellow 9.76 	 Red 10.08
```
#### Compare to flight 14.9.0 release
```
(ska3) ➜  starcheck git:(144485d) diff jul0824{-flight,}.txt
1,2c1,2
<  ------------  Starcheck 14.9.0    -----------------
<  Run on Wed Jul  3 09:22:43 EDT 2024 by aldcroft from saos-MacBook-Pro.local
---
>  ------------  Starcheck 14.10.1.dev1+g495d70c    -----------------
>  Run on Wed Jul  3 09:09:24 EDT 2024 by aldcroft from saos-MacBook-Pro.local
65c65
< OBSID = 26575 at 2024:192:22:53:13.261   7.8 ACQ | 5.0 GUI | Critical: 1 
---
> OBSID = 26575 at 2024:192:22:53:13.261   7.8 ACQ | 5.0 GUI | 
124c124
< Predicted Max CCD temperature: -4.4 C          N100 Warm Pix Frac 0.487
---
> Predicted Max CCD temperature: -4.4 C (-4.417 C)       N100 Warm Pix Frac 0.487
158c158
< Predicted Max CCD temperature: -4.8 C          N100 Warm Pix Frac 0.478
---
> Predicted Max CCD temperature: -4.8 C (-4.839 C)       N100 Warm Pix Frac 0.478
193c193
< Predicted Max CCD temperature: -5.1 C          N100 Warm Pix Frac 0.474
---
> Predicted Max CCD temperature: -5.1 C (-5.065 C)       N100 Warm Pix Frac 0.474
227c227
< Predicted Max CCD temperature: -5.7 C          N100 Warm Pix Frac 0.461
---
> Predicted Max CCD temperature: -5.7 C (-5.691 C)       N100 Warm Pix Frac 0.461
259c259
< Predicted Max CCD temperature: -6.0 C          N100 Warm Pix Frac 0.456
---
> Predicted Max CCD temperature: -6.0 C (-5.979 C)       N100 Warm Pix Frac 0.456
289c289
< Predicted Max CCD temperature: -7.4 C          N100 Warm Pix Frac 0.427
---
> Predicted Max CCD temperature: -7.4 C (-7.360 C)       N100 Warm Pix Frac 0.427
320c320
< Predicted Max CCD temperature: -7.6 C          N100 Warm Pix Frac 0.423
---
> Predicted Max CCD temperature: -7.6 C (-7.611 C)       N100 Warm Pix Frac 0.423
351c351
< Predicted Max CCD temperature: -8.2 C          N100 Warm Pix Frac 0.409
---
> Predicted Max CCD temperature: -8.2 C (-8.242 C)       N100 Warm Pix Frac 0.409
395c395
< Predicted Max CCD temperature: -8.6 C          N100 Warm Pix Frac 0.401
---
> Predicted Max CCD temperature: -8.6 C (-8.622 C)       N100 Warm Pix Frac 0.401
425c425
< Predicted Max CCD temperature: -8.8 C          N100 Warm Pix Frac 0.396
---
> Predicted Max CCD temperature: -8.8 C (-8.838 C)       N100 Warm Pix Frac 0.396
458c458
< Predicted Max CCD temperature: -7.8 C          N100 Warm Pix Frac 0.418
---
> Predicted Max CCD temperature: -7.8 C (-7.845 C)       N100 Warm Pix Frac 0.418
491c491
< Predicted Max CCD temperature: -4.3 C          N100 Warm Pix Frac 0.489
---
> Predicted Max CCD temperature: -4.3 C (-4.327 C)       N100 Warm Pix Frac 0.489
527c527
< Predicted Max CCD temperature: -4.0 C          N100 Warm Pix Frac 0.495
---
> Predicted Max CCD temperature: -4.0 C (-4.015 C)       N100 Warm Pix Frac 0.495
555,556d554
< 
< >> CRITICAL: CCD temperature exceeds -3.9 C
561c559
< Predicted Max CCD temperature: -3.9 C          N100 Warm Pix Frac 0.498
---
> Predicted Max CCD temperature: -3.9 C (-3.892 C)       N100 Warm Pix Frac 0.498
593c591
< Predicted Max CCD temperature: -4.0 C          N100 Warm Pix Frac 0.496
---
> Predicted Max CCD temperature: -4.0 C (-3.956 C)       N100 Warm Pix Frac 0.496
625c623
< Predicted Max CCD temperature: -5.5 C          N100 Warm Pix Frac 0.465
---
> Predicted Max CCD temperature: -5.5 C (-5.549 C)       N100 Warm Pix Frac 0.465
660c658
< Predicted Max CCD temperature: -6.6 C          N100 Warm Pix Frac 0.444
---
> Predicted Max CCD temperature: -6.6 C (-6.555 C)       N100 Warm Pix Frac 0.444
692c690
< Predicted Max CCD temperature: -8.2 C          N100 Warm Pix Frac 0.409
---
> Predicted Max CCD temperature: -8.2 C (-8.241 C)       N100 Warm Pix Frac 0.409
725c723
< Predicted Max CCD temperature: -9.0 C          N100 Warm Pix Frac 0.394
---
> Predicted Max CCD temperature: -9.0 C (-8.960 C)       N100 Warm Pix Frac 0.394
757c755
< Predicted Max CCD temperature: -9.4 C          N100 Warm Pix Frac 0.384
---
> Predicted Max CCD temperature: -9.4 C (-9.415 C)       N100 Warm Pix Frac 0.384
802c800
< Predicted Max CCD temperature: -9.4 C          N100 Warm Pix Frac 0.384
---
> Predicted Max CCD temperature: -9.4 C (-9.449 C)       N100 Warm Pix Frac 0.384
836c834
< Predicted Max CCD temperature: -6.4 C          N100 Warm Pix Frac 0.449
---
> Predicted Max CCD temperature: -6.4 C (-6.354 C)       N100 Warm Pix Frac 0.449
871c869
< Predicted Max CCD temperature: -5.9 C          N100 Warm Pix Frac 0.458
---
> Predicted Max CCD temperature: -5.9 C (-5.877 C)       N100 Warm Pix Frac 0.458
903c901
< Predicted Max CCD temperature: -5.9 C          N100 Warm Pix Frac 0.458
---
> Predicted Max CCD temperature: -5.9 C (-5.869 C)       N100 Warm Pix Frac 0.458
936c934
< Predicted Max CCD temperature: -5.7 C          N100 Warm Pix Frac 0.462
---
> Predicted Max CCD temperature: -5.7 C (-5.660 C)       N100 Warm Pix Frac 0.462
971c969
< Predicted Max CCD temperature: -5.5 C          N100 Warm Pix Frac 0.466
---
> Predicted Max CCD temperature: -5.5 C (-5.500 C)       N100 Warm Pix Frac 0.466
1003c1001
< Predicted Max CCD temperature: -5.7 C          N100 Warm Pix Frac 0.461
---
> Predicted Max CCD temperature: -5.7 C (-5.716 C)       N100 Warm Pix Frac 0.461
1038c1036
< Predicted Max CCD temperature: -4.2 C          N100 Warm Pix Frac 0.491
---
> Predicted Max CCD temperature: -4.2 C (-4.240 C)       N100 Warm Pix Frac 0.491
1071c1069
< Predicted Max CCD temperature: -4.1 C          N100 Warm Pix Frac 0.494
---
> Predicted Max CCD temperature: -4.1 C (-4.054 C)       N100 Warm Pix Frac 0.494
1104c1102
< Predicted Max CCD temperature: -4.2 C          N100 Warm Pix Frac 0.492
---
> Predicted Max CCD temperature: -4.2 C (-4.152 C)       N100 Warm Pix Frac 0.492
```
#### Format change does not impact parsing

```
In [5]: import starcheck.parser
   ...: flight = starcheck.parser.read_starcheck("jul0824-flight.txt")

In [6]: test = starcheck.parser.read_starcheck("jul0824-patch.txt")

In [7]: test == flight
Out[7]: True
```
