### PR TITLE
Refactor code and change format of HTML report

### DIFF
--- a/starcheck/plot.py
+++ b/starcheck/plot.py
@@ -48,19 +48,11 @@ def make_plots_for_obsid(obsid, ra, dec, roll, starcat_time, catalog, outdir,
 
     bad_stars = bad_acq_stars(stars)
 
-    f_plot = plot_stars(attitude=[ra, dec, roll], catalog=None, stars=stars,
-                        title=None, starcat_time=starcat_time, duration=duration,
-                        bad_stars=bad_stars, red_mag_lim=None)
-    f_plot.savefig(os.path.join(outdir, 'star_view_{}.png'.format(obsid)), dpi=80)
-    plt.close(f_plot)
     cat_plot = plot_stars(attitude=[ra, dec, roll], catalog=catalog, stars=stars,
                           title="RA=%.6f Dec=%.6f Roll=%.6f" % (ra, dec, roll),
                           starcat_time=starcat_time, duration=duration,
                           bad_stars=bad_stars, red_mag_lim=red_mag_lim)
-    cat_plot.savefig(os.path.join(outdir, 'stars_{}.png'.format(obsid)), dpi=80)
+    cat_plot.savefig(os.path.join(outdir, 'stars_{}.png'.format(obsid)), dpi=150)
     plt.close(cat_plot)
-    compass_plot = plot_compass(roll)
-    compass_plot.savefig(os.path.join(outdir, 'compass{}.png'.format(obsid)), dpi=80)
-    plt.close(compass_plot)
 
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2021,33 +2021,37 @@ sub get_report_html {
     my $c;
     my $o = '';    # Output
 
+    my $obsid = $self->{obsid};
+
     # Internal reference link
-    $o .= sprintf(
-        "<A NAME=\"obsid%s\">%s</A>",
-        $self->{obsid},
-        $self->get_report_prev_next_buttons_html()
-    );
+    $o .= "<!-- Start of HTML report content for obsid $obsid -->\n";
 
     # Main table for per-obsid report
+    $o .= "<!-- Main table for per-obsid report for obsid $obsid -->\n";
     $o .= "<TABLE CELLPADDING=0>\n";
-    $o .= "<TR>\n";
 
-    # Left side of table with pre-formatted text
-    $o .= "<TD VALIGN=TOP WIDTH=810>";
-    $o .= "<PRE>";
+    # Left side of table with nav links and pre-formatted text
+    $o .= "<TD VALIGN=TOP WIDTH=810>\n";
+    my $nav_buttons = $self->get_report_prev_next_buttons_html();
+    $o .= qq{<A NAME="obsid$obsid">$nav_buttons</A>\n};
+    $o .= "<BR>\n";
+    $o .= "<!-- Star catalog preformatted information and table for obsid $obsid -->\n";
+    $o .= "<PRE>\n";
     $o .= $self->get_report_header_html();
     $o .= $self->get_report_starcat_table_html();
     $o .= $self->get_report_footer_html();
-    $o .= "</PRE>";
-    $o .= "</TD>";
+    $o .= "</PRE>\n";
+    $o .= "</TD>\n";
 
     # Right side with images: starfield big, starfield small, compass
-    $o .= "<TD VALIGN=TOP>";
+    $o .= "<!-- Star field plot for obsid $obsid -->\n";
+    $o .= "<TD VALIGN=TOP>\n";
     $o .= $self->get_report_images_html();
-    $o .= "</TD>";
-    $o .= "</TR>";
-    $o .= "</TABLE>";
+    $o .= "</TD>\n";
 
+    $o .= "</TR>\n";
+    $o .= "</TABLE>\n";
+    $o .= "<!-- End of HTML report content for obsid $obsid -->\n";
     return $o;
 }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2819,7 +2819,7 @@ sub star_image_map {
           . 'ONMOUSEOUT="return nd();"' . "\n"
           . 'SHAPE="circle"' . "\n"
           . 'ALT=""' . "\n"
-          . "COORDS=\"$image_x,$image_y,2\">" . "\n";
+          . "COORDS=\"$image_x,$image_y,3\">" . "\n";
         $map .= $star;
     }
     $map .= "</map> \n";

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2510,27 +2510,14 @@ sub get_report_footer_html {
 
 sub get_report_images_html {
     my $self = shift;
+    my $img_size = 600;
 
-    my $pict1 = qq{};
-    my $pict2 = qq{};
-    my $pict3 = qq{};
+    my $out = "";
     if ($self->{plot_file}) {
         my $obs = $self->{obsid};
-        my $obsmap = $self->star_image_map();
-        $pict1 = qq{$obsmap <img src="$self->{plot_file}" usemap=\#starmap_${obs}
-						width=426 height=426 border=0> };
+        $out .= $self->star_image_map($img_size);
+        $out .= qq{<img src="$self->{plot_file}" usemap=\#starmap_${obs} width=$img_size height=$img_size border=0> };
     }
-    if ($self->{plot_field_file}) {
-        $pict2 =
-qq{Star Field<BR /><img align="top" src="$self->{plot_field_file}" width=231 height=231>};
-    }
-    if ($self->{compass_file}) {
-        $pict3 =
-qq{Compass<BR /><img align="top" src="$self->{compass_file}" width=154 height=154>};
-    }
-
-    my $out =
-"<TABLE CELLPADDING=0><TR><TD ROWSPAN=2>$pict1</TD><TD ALIGN=CENTER>$pict2</TD></TR><TR><TD ALIGN=CENTER>$pict3</TD></TR></TABLE>\n";
     return $out;
 }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2746,6 +2746,7 @@ sub star_dbhist {
 sub star_image_map {
 #############################################################################################
     my $self = shift;
+    my $img_size = shift;
     my $c;
     return unless ($c = find_command($self, 'MP_STARCAT'));
     return
@@ -2777,12 +2778,13 @@ sub star_image_map {
         $star_count++;
     }
 
-    # notes for pixel scaling.
-    # these will need to change if we resize the images.
-    # top right +384+39
-    # top left +54+39
-    # 2900x2900
-    my $pix_scale = 330 / (2900. * 2);
+    # For a 798x798 image (native with dpi=150), -2900 to 2900 arcsec is 619 pixels.
+    # The top left corner is at x=100, y=63 pixels.
+    my $img_size_ref = 798;  # pixels
+    my $img_size_scale = $img_size / $img_size_ref;
+    my $pix_scale = 619 / (2900. * 2) * $img_size_scale;
+    my $x_offset = 100 * $img_size_scale;
+    my $y_offset = 63 * $img_size_scale;
 
     # Convert all the yag/zags to pixel rows/cols
     my @yags = map { $self->{agasc_hash}->{$_}->{yag} } keys %plot_ids;
@@ -2800,8 +2802,8 @@ sub star_image_map {
         my $sid = $cat_star->{id};
         my $yag = $cat_star->{yag};
         my $zag = $cat_star->{zag};
-        my $image_x = 54 + ((2900 - $yag) * $pix_scale);
-        my $image_y = 39 + ((2900 - $zag) * $pix_scale);
+        my $image_x = $x_offset + (2900 - $yag) * $pix_scale;
+        my $image_y = $y_offset + (2900 - $zag) * $pix_scale;
         my $star =
             '<area href="javascript:void(0);"' . "\n"
           . 'ONMOUSEOVER="return overlib ('

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2024,10 +2024,10 @@ sub get_report_html {
     my $obsid = $self->{obsid};
 
     # Internal reference link
-    $o .= "<!-- Start of HTML report content for obsid $obsid -->\n";
+    $o .= "<!-- Start of HTML report content for obsid $obsid -->";
 
     # Main table for per-obsid report
-    $o .= "<!-- Main table for per-obsid report for obsid $obsid -->\n";
+    $o .= "<!-- Main table for per-obsid report for obsid $obsid -->";
     $o .= "<TABLE CELLPADDING=0>\n";
 
     # Left side of table with nav links and pre-formatted text
@@ -2036,7 +2036,7 @@ sub get_report_html {
     $o .= qq{<A NAME="obsid$obsid">$nav_buttons</A>\n};
     $o .= "<BR>\n";
     $o .= "<!-- Star catalog preformatted information and table for obsid $obsid -->\n";
-    $o .= "<PRE>\n";
+    $o .= "<PRE>";
     $o .= $self->get_report_header_html();
     $o .= $self->get_report_starcat_table_html();
     $o .= $self->get_report_footer_html();

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -665,9 +665,12 @@ open(my $JSON_OUT, "> $STARCHECK/obsids.json")
 print $JSON_OUT $final_json;
 close($JSON_OUT);
 
-# Produce final report
-
-my $out = '<TABLE><TD><PRE> ';
+######################################################################
+# Produce final HTML report
+######################################################################
+my $out = '';
+# $out .= '<TABLE><TD>';
+$out .= '<PRE>';
 my $date = `date`;
 chomp $date;
 
@@ -897,33 +900,14 @@ $out .= "\n";
 # For each obsid, print star report, errors, and generate star plot
 
 foreach $obsid (@obsid_id) {
-    $out .= "<HR>\n";
-    $out .= $obs{$obsid}->print_report();
-    my $pict1 = qq{};
-    my $pict2 = qq{};
-    my $pict3 = qq{};
-    if ($obs{$obsid}->{plot_file}) {
-        my $obs = $obs{$obsid}->{obsid};
-        my $obsmap = $obs{$obsid}->star_image_map();
-        $pict1 = qq{$obsmap <img src="$obs{$obsid}->{plot_file}" usemap=\#starmap_${obs}
-						width=426 height=426 border=0> };
-    }
-    if ($obs{$obsid}->{plot_field_file}) {
-        $pict2 =
-qq{Star Field<BR /><img align="top" src="$obs{$obsid}->{plot_field_file}" width=231 height=231>};
-    }
-    if ($obs{$obsid}->{compass_file}) {
-        $pict3 =
-qq{Compass<BR /><img align="top" src="$obs{$obsid}->{compass_file}" width=154 height=154>};
-    }
-
-    $out .=
-"<TABLE CELLPADDING=0><TR><TD ROWSPAN=2>$pict1</TD><TD ALIGN=CENTER>$pict2</TD></TR><TR><TD ALIGN=CENTER>$pict3</TD></TR></TABLE>\n";
+    $out .= "<HR>";
+    $out .= $obs{$obsid}->get_report_html();
 }
 
 # Finish up and format it
 
-$out .= '</PRE></TD></TABLE> ';
+$out .= '</PRE>';
+# $out .= '</TD></TABLE> ';
 
 #print $out;
 

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -900,7 +900,7 @@ $out .= "\n";
 # For each obsid, print star report, errors, and generate star plot
 
 foreach $obsid (@obsid_id) {
-    $out .= "<HR>";
+    $out .= "<HR>\n";
     $out .= $obs{$obsid}->get_report_html();
 }
 


### PR DESCRIPTION
## Description

This PR does two things:
- Refactor the per-obsid code that generates the HTML report output into smaller functions.
- Change the output HTML:
  - Move the Next/Prev buttons above the pre-formatted report information.
  - Remove the compass and small star field plot.
  - Move the star catalog plot to the right and make it bigger.
- The hover-over coordinates have been refined a bit so the mouse position is closer to the star center when the pop-up appears.

Output: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr448/FEB1025a_test.html


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
jeanconn-kady> git rev-parse HEAD
fb6377ddb1c95e3327e3ac9ef7fe1620392d0167
jeanconn-kady> pytest
============================================================== test session starts ===============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 14 items                                                                                                                               

starcheck/tests/test_state_checks.py .............                                                                                         [ 92%]
starcheck/tests/test_utils.py .                                                                                                            [100%]

============================================================== 14 passed in 10.76
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
For the FEB1025A loads, the only diff in the `starcheck.txt` output between this PR and current master was the first line giving the run date.

There are regression outputs against the masters-run version

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr448/

which show the expected changes related to running the test version.
The new output also removes an extra space at the beginning of the text output which seemed appropriate (looks like the leading space was a bug).  Also, the starcheck parser notes no diffs between the masters output and this PR test output.

```
In [2]: import starcheck.parser

In [3]: release = starcheck.parser.read_starcheck('FEB1725a_flight.txt')

In [4]: test = starcheck.parser.read_starcheck("FEB1725a_test.txt")

In [5]: release == test
Out[5]: True
```