### PR TITLE
Don't run flight starcheck from in the repo

### DIFF
--- a/starcheck/src/starcheck
+++ b/starcheck/src/starcheck
@@ -1,13 +1,16 @@
 #!/bin/bash
 
-# Don't unset LD_LIBRARY_PATH and SYBASE because 'perl' below
-# is no longer a wrapper
-#unset LD_LIBRARY_PATH
-#unset SYBASE
-
 # Unset PYTHONPATH because custom PYTHONPATH should never be allowed
 # for flight starcheck
 unset PYTHONPATH
+
+# If this script is being run from inside the starcheck git repo, exit
+# with an informative message.
+if [[ -f starcheck/__init__.py ]];
+then
+    echo "Do not run flight starcheck from the source repo. (found ./starcheck/__init__.py)"
+    exit 1
+fi
 
 PYTHON_EXE=`which python`
 PYTHON_DIR=`dirname $PYTHON_EXE`


### PR DESCRIPTION
## Description

And a conditional to the flight starcheck wrapper to exit if it finds 'starcheck/__init__.py' indicating that it is being run in the repo.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests
(this fix can't be unit tested)

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I just pip-installed and tried to run starcheck from the repo and get
```
(ska3-flight-2025.1rc2) flame:starcheck jean$ starcheck -dir FEB2425A -out test
Do not run flight starcheck from the source repo. (found ./starcheck/__init__.py)
```
