### PR TITLE
Remove high IR zone check

### DIFF
--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -728,24 +728,6 @@ if (@global_warn) {
     $out .= qq{${font_stop}\n};
 }
 
-# Check for just NMAN during high IR Zone
-$out .= "------------  HIGH IR ZONE CHECK  -----------------\n\n";
-my $ir_report = "${STARCHECK}/high_ir_check.txt";
-my $ir_ok = call_python(
-    "utils.make_ir_check_report",
-    [],
-    {
-        backstop_file => $backstop,
-        out => $ir_report
-    }
-);
-if ($ir_ok) {
-    $out .= "<A HREF=\"${ir_report}\">[OK] In NMAN during High IR Zones.</A>\n";
-}
-else {
-    $out .= "<A HREF=\"${ir_report}\">[${red_font_start}NOT OK${font_stop}]";
-    $out .= " Not in NMAN during High IR Zone.</A>\n";
-}
 
 # Run independent attitude checker
 my $ATT_CHECK_AFTER = '2015:315:00:00:00.000';

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -32,7 +32,6 @@ import kadi.commands.states as kadi_states
 import starcheck
 from starcheck import __version__ as version
 from starcheck.calc_ccd_temps import get_ccd_temps
-from starcheck.state_checks import ir_zone_ok
 from starcheck.plot import make_plots_for_obsid
 
 ACQS = mica.stats.acq_stats.get_stats()
@@ -128,10 +127,6 @@ def get_kadi_scenario():
 def get_data_dir():
     sc_data = os.path.join(os.path.dirname(starcheck.__file__), "data")
     return sc_data if os.path.exists(sc_data) else ""
-
-
-def make_ir_check_report(**kwargs):
-    return ir_zone_ok(**kwargs)
 
 
 def get_dither_kadi_state(date):


### PR DESCRIPTION
## Description

Remove check for NMM in the high IR zone as this is no longer needed.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
ae6d9db81c04bb04f8f4ee364fc7c0c5cb35874c
ska3-jeanconn-fido> pytest
================================================= test session starts ==================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 14 items                                                                                                     

starcheck/tests/test_state_checks.py .............                                                               [ 92%]
starcheck/tests/test_utils.py .                                                                                  [100%]

================================================= 14 passed in 21.42s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Given that this does not change logic or formatting besides just removing a recently-added section of the report, I just ran one week as a functional and regression test and confirmed that the check text was removed, there were no new warnings or failures, and the diffs against output from master (not flight) are as expected.

Diff https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr450/diff.html

New output https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr450/mar1025a_test.html



