### PR TITLE
Add checks for no dither and small dither observations

### DIFF
--- a/starcheck/src/lib/Ska/Parse_CM_File.pm
+++ b/starcheck/src/lib/Ska/Parse_CM_File.pm
@@ -160,7 +160,9 @@ sub dither {
         'state' => $dither_enab,
         'source' => 'kadi',
         'ampl_p' => $dither_ampl_p,
+        'ampl_p_int' => int($dither_ampl_p + 0.5), # rounded for convenience in checks
         'ampl_y' => $dither_ampl_y,
+        'ampl_y_int' => int($dither_ampl_y + 0.5), # rounded for convenience in checks
         'period_p' => $dither_period_p,
         'period_y' => $dither_period_y
       };
@@ -186,15 +188,21 @@ sub dither {
                 $dither_period_y = 1 / ($params{RATEY} / (2 * $pi))
                   if defined $params{RATEP};
 
-         # If disabled, reset the amplitudes to be 0.  The params may be nonzero onboard
+                # If disabled, reset the amplitudes to be 0.  The params may be nonzero onboard
                 # but we're more interested in the effective amplitudes for starcheck.
+                my $ampl_p = $dither_enab eq 'DISA' ? 0 : $dither_ampl_p;
+                my $ampl_y = $dither_enab eq 'DISA' ? 0 : $dither_ampl_y;
+
+                # Push the new dither state to the array
                 push @dither,
                   {
                     time => $bs->{time},
                     state => $dither_enab,
                     source => 'backstop',
-                    ampl_p => $dither_enab eq 'DISA' ? 0 : $dither_ampl_p,
-                    ampl_y => $dither_enab eq 'DISA' ? 0 : $dither_ampl_y,
+                    ampl_p => $ampl_p,
+                    ampl_y => $ampl_y,
+                    ampl_p_int => int($ampl_p + 0.5),
+                    ampl_y_int => int($ampl_y + 0.5),
                     period_p => $dither_period_p,
                     period_y => $dither_period_y,
                     tlmsid => $params{TLMSID},

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -810,12 +810,12 @@ sub standard_dither {
     my %standard_dither_y = (
         20 => 1087.0,
         16 => 1414.2,
-        8 => 1000.0
+        8 => 707.1
     );
     my %standard_dither_p = (
         20 => 768.6,
         16 => 2000.0,
-        8 => 707.1
+        8 => 1000.0
     );
 
     my $ampl_p = int($dthr->{ampl_p} + 0.5);

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2982,22 +2982,6 @@ sub set_ccd_temps {
           sprintf("CCD temperature exceeds %.1f C\n", $ccd_temp_red_limit_round);
     }
 
-    # Add info for having a penalty temperature too
-    if (defined $config{ccd_temp_yellow_limit}) {
-        if ($self->{ccd_temp} > $config{ccd_temp_yellow_limit}) {
-            push @{ $self->{fyi} },
-              sprintf("Effective guide temperature %.1f C\n",
-                $self->{ccd_temp});
-
-        }
-        if ($self->{ccd_temp_acq} > $config{ccd_temp_yellow_limit}) {
-            push @{ $self->{fyi} },
-              sprintf("Effective acq temperature %.1f C\n",
-                $self->{ccd_temp_acq});
-
-        }
-    }
-
 # Clip the acq ccd temperature to the calibrated range of the grid acq probability model
     # and add a yellow warning to let the user know this has happened.
     if (($self->{ccd_temp_acq} > 2.0) or ($self->{ccd_temp_acq} < -15.0)) {

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2900,12 +2900,13 @@ sub check_guide_count {
 ###################################################################################
     my $self = shift;
 
-    # Disable dynamic background if guide dither is disabled or amplitude is zero
+    # Disable dynamic background if guide dither is disabled or amplitude is small
     my $guide_dither = $self->{dither_guide};
     my $dyn_bgd;
+    my $guide_dither_ampl_y = int($guide_dither->{ampl_y} + 0.5);
+    my $guide_dither_ampl_p = int($guide_dither->{ampl_p} + 0.5);
     if (   ($guide_dither->{state} eq 'DISA')
-        or (($guide_dither->{ampl_y} == 0)
-        and ($guide_dither->{ampl_p} == 0)))
+        or (($guide_dither_ampl_y == 0) and ($guide_dither_ampl_p == 0)))
     {
         $dyn_bgd = 0;
     }
@@ -2915,7 +2916,8 @@ sub check_guide_count {
 
     # If dyn_bgd is disabled, push an info statement
     if ($dyn_bgd == 0) {
-        push @{ $self->{fyi} }, "Dynamic background bonus disabled - OFF or 0 guide dither.\n";
+        push @{ $self->{fyi} },
+        "Dither disabled or 0 - dynamic background bonus disabled for guide count.\n";
     }
 
     my $guide_count = $self->count_guide_stars($dyn_bgd);

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2987,13 +2987,13 @@ sub set_ccd_temps {
         if ($self->{ccd_temp} > $config{ccd_temp_yellow_limit}) {
             push @{ $self->{fyi} },
               sprintf("Effective guide temperature %.1f C\n",
-                call_python("utils.get_effective_t_ccd", [ $self->{ccd_temp} ]));
+                $self->{ccd_temp});
 
         }
         if ($self->{ccd_temp_acq} > $config{ccd_temp_yellow_limit}) {
             push @{ $self->{fyi} },
               sprintf("Effective acq temperature %.1f C\n",
-                call_python("utils.get_effective_t_ccd", [ $self->{ccd_temp_acq} ]));
+                $self->{ccd_temp_acq});
 
         }
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -688,7 +688,6 @@ sub check_dither {
 
     # Small dither check for with creep-away
     my $targ_cmd = find_command($self, "MP_TARGQUAT", -1);
-    my $cat_cmd = find_command($self, "MP_STARCAT");
     my $man_angle_next_data = call_python("state_checks.get_obs_man_angle_next",
                 [ $targ_cmd->{tstop}, $self->{backstop} ]);
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -820,7 +820,7 @@ sub standard_dither {
     return 0 unless abs($dthr->{period_y} - $standard_dither_y{$ampl_y}) < 10;
 
     # If those tests passed, the dither is standard
-    return (($ampl_y == 20) && ($ampl_p == 20)) ? 'hrc' : 'acis';
+    return (($ampl_y == 20) and ($ampl_p == 20)) ? 'hrc' : 'acis';
 
 }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2866,8 +2866,8 @@ sub check_guide_count {
     my $guide_dither = $self->{dither_guide};
     my $dyn_bgd;
     if (   ($guide_dither->{state} eq 'DISA')
-        or ($guide_dither->{ampl_y} == 0)
-        and ($guide_dither->{ampl_p} == 0))
+        or (($guide_dither->{ampl_y} == 0)
+        and ($guide_dither->{ampl_p} == 0)))
     {
         $dyn_bgd = 0;
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -802,43 +802,45 @@ sub check_dither {
     }
 }
 
+sub is_within_threshold {
+    my ($value, $allowed_values, $threshold) = @_;
+    foreach my $allowed (@$allowed_values) {
+        return 1 if abs($value - $allowed) <= $threshold;
+    }
+    return 0;
+}
+
 #############################################################################################
 sub standard_dither {
 #############################################################################################
     my $dthr = shift;
     my %standard_dither_y = (
-        20 => 1087.0,
-        16 => 1414.2,
-        8 => 707.1
+        20 => [1087.0],
+        16 => [1414.2],
+        8 => [707.1, 1000],
     );
     my %standard_dither_p = (
-        20 => 768.6,
-        16 => 2000.0,
-        8 => 1000.0
+        20 => [768.6],
+        16 => [2000.0],
+        8 => [707.1, 1000.0],
     );
 
     my $ampl_p = int($dthr->{ampl_p} + 0.5);
     my $ampl_y = int($dthr->{ampl_y} + 0.5);
 
-    # If the rounded amplitude is not in the standard set, return 0
-    if (not(grep $_ eq $ampl_p, (keys %standard_dither_p))) {
-        return 0;
-    }
-    if (not(grep $_ eq $ampl_y, (keys %standard_dither_y))) {
-        return 0;
-    }
+    # Check if amplitudes are valid
+    return 0 unless exists $standard_dither_p{$ampl_p};
+    return 0 unless exists $standard_dither_y{$ampl_y};
 
-    # If the period is not standard for the standard amplitudes return 0
-    if (abs($dthr->{period_p} - $standard_dither_p{$ampl_p}) > 10) {
-        return 0;
-    }
-    if (abs($dthr->{period_y} - $standard_dither_y{$ampl_y}) > 10) {
-        return 0;
-    }
+    # Check if periods are within the threshold for the given amplitudes
+    return 0 unless is_within_threshold($dthr->{period_p}, $standard_dither_p{$ampl_p}, 10);
+    return 0 unless is_within_threshold($dthr->{period_y}, $standard_dither_y{$ampl_y}, 10);
 
     # If those tests passed, the dither is standard
-    return (($ampl_y == 20) & ($ampl_p == 20)) ? 'hrc' : 'acis';
+    return (($ampl_y == 20) && ($ampl_p == 20)) ? 'hrc' : 'acis';
+
 }
+
 
 #############################################################################################
 sub large_dither_checks {

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -698,7 +698,7 @@ sub check_dither {
     my $creep_away = ($man_angle_next_data->{"angle"} < 5.0);
     my $no_dither = (($guide_dither->{state} eq 'DISA')
             or (($guide_dither_ampl_y == 0) and ($guide_dither_ampl_p == 0)));
-    my $small_dither = ($guide_dither_ampl_y < 8) and ($guide_dither_ampl_p < 8) and (not $no_dither);
+    my $small_dither = (($guide_dither_ampl_y < 8) and ($guide_dither_ampl_p < 8) and (not $no_dither));
 
     if ($no_dither) {
         if ($creep_away) {

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -695,33 +695,23 @@ sub check_dither {
     my $guide_dither_ampl_p = int($guide_dither->{ampl_p} + 0.5);
     my $guide_dither_ampl_y = int($guide_dither->{ampl_y} + 0.5);
 
-    # If not creep-away
-    if ($man_angle_next_data->{"angle"} > 5.0){
-        if (($guide_dither->{state} eq 'DISA')
-            or (($guide_dither_ampl_y == 0) and ($guide_dither_ampl_p == 0))){
-                push @{ $self->{warn} }, "Maneuver angle away > 5.0 degrees and 0 or DISA dither\n";
-        }
-        else{
-            if (($guide_dither_ampl_y < 8) and ($guide_dither_ampl_p < 8)){
-                push @{ $self->{warn}}, "Small dither but no creep-away - double-check config\n"
-            }
-        }
-    }
-    # If creep away and no dither
-    else{
-        if (($guide_dither->{state} eq 'DISA')
-            or (($guide_dither_ampl_y == 0) and ($guide_dither_ampl_p < 0))){
-                push @{ $self->{fyi} }, "Dither disabled or 0 - properly configured with creep-away\n";
-        }
-    }
+    my $creep_away = ($man_angle_next_data->{"angle"} < 5.0);
+    my $no_dither = (($guide_dither->{state} eq 'DISA')
+            or (($guide_dither_ampl_y == 0) and ($guide_dither_ampl_p == 0)));
+    my $small_dither = ($guide_dither_ampl_y < 8) and ($guide_dither_ampl_p < 8) and (not $no_dither);
 
-    # If dither between 0 and 8, that's unexpected overall at this point enough to get orange warn.
-    if (($guide_dither->{state} eq 'ENAB') and
-        (($guide_dither_ampl_y < 8) and ($guide_dither_ampl_p < 8))
-        & (($guide_dither_ampl_y> 0) or ($guide_dither_ampl_p > 0))){
-        push @{ $self->{orange_warn} }, "Unexpected small but not zero dither\n";
+    if ($no_dither) {
+        if ($creep_away) {
+            push @{ $self->{fyi} }, "No dither but with proper creep-away\n";
+        } else {
+            push @{ $self->{warn} }, "Creep-away required with no dither\n";
+        }
+    } elsif ($small_dither) {
+        if ($creep_away) {
+            push @{ $self->{warn}}, "Small (< 8 arcsec) dither but no creep-away - double-check\n"
+        }
+        push @{ $self->{orange_warn} }, "Small (< 8 arcsec) dither -- double-check\n";
     }
-
 
     # Check for dither changes during the observation
     # ACA-003

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2865,7 +2865,7 @@ sub check_guide_count {
     # Disable dynamic background if guide dither is disabled or amplitude is zero
     my $guide_dither = $self->{dither_guide};
     my $dyn_bgd;
-    if (   ($guide_dither->{state} eq 'DISAB')
+    if (   ($guide_dither->{state} eq 'DISA')
         or ($guide_dither->{ampl_y} == 0)
         and ($guide_dither->{ampl_p} == 0))
     {

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -792,27 +792,20 @@ sub check_dither {
     }
 }
 
-sub is_within_threshold {
-    my ($value, $allowed_values, $threshold) = @_;
-    foreach my $allowed (@$allowed_values) {
-        return 1 if abs($value - $allowed) <= $threshold;
-    }
-    return 0;
-}
 
 #############################################################################################
 sub standard_dither {
 #############################################################################################
     my $dthr = shift;
     my %standard_dither_y = (
-        20 => [1087.0],
-        16 => [1414.2],
-        8 => [707.1, 1000],
+        20 => 1087.0,
+        16 => 1414.2,
+        8 => 707.1,
     );
     my %standard_dither_p = (
-        20 => [768.6],
-        16 => [2000.0],
-        8 => [707.1, 1000.0],
+        20 => 768.6,
+        16 => 2000.0,
+        8 => 1000.0,
     );
 
     my $ampl_p = int($dthr->{ampl_p} + 0.5);
@@ -823,8 +816,8 @@ sub standard_dither {
     return 0 unless exists $standard_dither_y{$ampl_y};
 
     # Check if periods are within the threshold for the given amplitudes
-    return 0 unless is_within_threshold($dthr->{period_p}, $standard_dither_p{$ampl_p}, 10);
-    return 0 unless is_within_threshold($dthr->{period_y}, $standard_dither_y{$ampl_y}, 10);
+    return 0 unless abs($dthr->{period_p} - $standard_dither_p{$ampl_p}) < 10;
+    return 0 unless abs($dthr->{period_y} - $standard_dither_y{$ampl_y}) < 10;
 
     # If those tests passed, the dither is standard
     return (($ampl_y == 20) && ($ampl_p == 20)) ? 'hrc' : 'acis';

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2899,7 +2899,7 @@ sub check_guide_count {
     my $guide_dither_ampl_y = $guide_dither->{ampl_y_int};
     my $guide_dither_ampl_p = $guide_dither->{ampl_p_int};
     if (   ($guide_dither->{state} eq 'DISA')
-        or (($guide_dither_ampl_y == 0) and ($guide_dither_ampl_p == 0)))
+        or (($guide_dither_ampl_y < 8) and ($guide_dither_ampl_p < 8)))
     {
         $dyn_bgd = 0;
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2887,7 +2887,9 @@ sub check_guide_count {
 ###################################################################################
     my $self = shift;
 
-    # Disable dynamic background if guide dither is disabled or amplitude is small
+    # Disable dynamic background if guide dither is disabled or amplitude is small.
+    # The dynamic background isn't as effective with small dither so the temperature
+    # "bonus" should not be applied to the guide count.  Introduced in PR #452.
     my $guide_dither = $self->{dither_guide};
     my $dyn_bgd;
     my $guide_dither_ampl_y = int($guide_dither->{ampl_y} + 0.5);

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -707,7 +707,7 @@ sub check_dither {
             push @{ $self->{warn} }, "Creep-away required with no dither\n";
         }
     } elsif ($small_dither) {
-        if ($creep_away) {
+        if (not $creep_away) {
             push @{ $self->{warn}}, "Small (< 8 arcsec) dither but no creep-away - double-check\n"
         }
         push @{ $self->{orange_warn} }, "Small (< 8 arcsec) dither -- double-check\n";

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -702,7 +702,7 @@ sub check_dither {
 
     if ($no_dither) {
         if ($creep_away) {
-            push @{ $self->{fyi} }, "No dither but with proper creep-away\n";
+            push @{ $self->{fyi} }, "Dither disabled or 0 - properly configured with creep-away\n";
         } else {
             push @{ $self->{warn} }, "Creep-away required with no dither\n";
         }

--- a/starcheck/state_checks.py
+++ b/starcheck/state_checks.py
@@ -174,3 +174,20 @@ def get_obs_man_angle(npnt_tstart, backstop_file):
     dur = prev_state["tstop"] - prev_state["tstart"]
     angle = calc_man_angle_for_duration(dur)
     return {"angle": angle}
+
+
+def get_obs_man_angle_next(npnt_tstart, backstop_file):
+    states, _ = get_pcad_states(backstop_file)
+    nman_states = states[states["pcad_mode"] == "NMAN"]
+    idx = np.argmin(np.abs(CxoTime(npnt_tstart).secs - nman_states["tstop"]))
+    if idx == len(nman_states) - 1:
+        next_state = None
+    else:
+        next_state = nman_states[idx + 1]
+
+    if next_state is None:
+        warn = f"No NMAN state after {CxoTime(npnt_tstart).date}\n"
+        return {"angle": 180, "warn": warn}
+    dur = next_state["tstop"] - next_state["tstart"]
+    angle = calc_man_angle_for_duration(dur)
+    return {"angle": angle}

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -300,6 +300,7 @@ def guide_count(mags, t_ccd, count_9th, date, dyn_bgd=True):
                   penalty, so input t_ccd should not have penalty applied)
     :param count_9th: bool or 0 or 1 for whether to use count_9th mode
     :param date: date of observation
+    :param dyn_bgd: whether to apply dynamic background bonus
     :returns: fractional guide_count as float
     """
     if dyn_bgd:

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -270,12 +270,11 @@ def apply_t_ccds_bonus(mags, t_ccd, date):
     Apply dynamic background bonus temperatures.
 
     Calculate the dynamic background bonus temperatures for a given set of
-    magnitudes, t_ccd (which should be the effective t_ccd with any penalty applied),
-    and date. This applies values of dyn_bgd_n_faint and dyn_bgd_dt_ccd.
+    magnitudes, t_ccd and date. This applies values of dyn_bgd_n_faint and dyn_bgd_dt_ccd.
     This calls chandra_aca.sparkles.get_t_ccds_bonus.
 
     :param mags: list of magnitudes
-    :param t_ccd: effective t_ccd
+    :param t_ccd: t_ccd
     :param date: date. Used to determine default value of dyn_bgd_n_faint and set
                  dyn_bgd_n_faint to 2 after PEA patch uplink and activation on 2023:139.
     :returns: list of dynamic background bonus temperatures (degC) in the order of mags

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -286,7 +286,7 @@ def apply_t_ccds_bonus(mags, t_ccd, date):
     return sparkles.get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint, dyn_bgd_dt_ccd)
 
 
-def guide_count(mags, t_ccd, count_9th, date):
+def guide_count(mags, t_ccd, count_9th, date, dyn_bgd=True):
     """
     Get guide count.
 
@@ -302,8 +302,11 @@ def guide_count(mags, t_ccd, count_9th, date):
     :param date: date of observation
     :returns: fractional guide_count as float
     """
-    eff_t_ccd = get_effective_t_ccd(t_ccd)
-    t_ccds_bonus = apply_t_ccds_bonus(mags, eff_t_ccd, date)
+    if dyn_bgd:
+        eff_t_ccd = get_effective_t_ccd(t_ccd)
+        t_ccds_bonus = apply_t_ccds_bonus(mags, eff_t_ccd, date)
+    else:
+        t_ccds_bonus = [t_ccd] * len(mags)
     return float(
         chandra_aca.star_probs.guide_count(np.array(mags), t_ccds_bonus, count_9th)
     )


### PR DESCRIPTION
## Description

Add checks for no dither and small dither observations and remove penalty-limit-based effective t_ccd calculation.

The idea is that observations with no dither should have creep-away and should be reviewed without the benefit of the dynamic background bonus applied to guide count.

This PR also adds a new warning for observations with non-zero dither less than 8 arcsec in both axes as that is unexpected at this point and would similarly not benefit from dynamic background.

A change has also been added to have the dither periods match those currently in use such that there should be no "Non-standard dither" warnings unless true non-standard patterns are used.

This PR also removes the effective ccd temperature calculation as this is no longer needed with the deprecation of the penalty limit.  This change is effectively a no-op.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) flame:starcheck jean$ git rev-parse HEAD
ceec84615d69de374199211d55acefac3a1d50be
(ska3) flame:starcheck jean$ pytest
========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 14 items                                                                                                                                                      

starcheck/tests/test_state_checks.py .............                                                                                                                [ 92%]
starcheck/tests/test_utils.py .                                                                                                                                   [100%]

========================================================================== 14 passed in 3.98s
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
A set of weeks was run in regression that shows the expected changes.

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr452/

These outputs also include functional review.  Week JAN0325A shows the recent no dither observations have new info statements that note the correct configurations.
```
+>> INFO    : Dither disabled or 0 - dynamic background bonus disabled for guide count.
+>> INFO    : Dither disabled or 0 - properly configured with creep-away
```

A bunch of schedules include new removal of non-standard dither warnings as these were due to some confusion in the code about what was expected for the period of the 8-arcsec half-amplitude dither in some cases.  This is actually a bug fix in this code.  The MAR0325A week includes observations with the reduced dither in one axis on ACIS-I (more rare).
```
->> CAUTION : Non-standard dither
```

The MAR1723 week shows a new warnings  intended for small dither configs and the guide count reduced due to dynamic background bonus being disabled for 4x4.
```
+>> CRITICAL: Guide count of 3.4 < 4.
+>> WARNING : Small (< 8 arcsec) dither -- double-check
+>> INFO    : Dither disabled or 0 - dynamic background bonus disabled for guide count.
```

The MAR1723 week also shows more of these warnings
```
+>> CAUTION : Non-standard dither
```
As the standard dither checks have not been set to be backward compatible with observations before the fall of 2023.

To functionally check that the dynamic background bonus is disabled for the dither disabled observations, I just added some temporary print statements in starcheck.utils to print the bonus applied temperatures, and reviewed this for the dither disabled observations.

Here is the output and t_ccds in master
```
Checking star catalog for obsid 29897
date: 2025:006:12:11:44.865
t_ccds_bonus: [-5.36332083 -5.36332083 -5.36332083 -9.36332083 -9.36332083]
mags: [7.031, 7.857, 7.968, 8.575, 8.889]
count_9th: 0
```

And the output and t_ccds in this branch.  Note just the change in the effective t_ccd for the last two stars.
```
Checking star catalog for obsid 29897
date: 2025:006:12:11:44.865
t_ccds_bonus: [-5.36332083143338, -5.36332083143338, -5.36332083143338, -5.36332083143338, -5.36332083143338]
mags: [7.031, 7.857, 7.968, 8.575, 8.889]
count_9th: 0
```
