### PR TITLE
Move large dither check before dither-in-obs check again

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -656,33 +656,6 @@ sub check_dither {
     $guide_dither->{ampl_y_max} = $guide_dither->{ampl_y};
     $guide_dither->{ampl_p_max} = $guide_dither->{ampl_p};
 
-    # Check for dither changes during the observation.
-    # This also updates the maximum amplitude for any observation that has dither
-    # changes.
-    # ACA-003
-    if (not defined $obs_tstop) {
-        push @{ $self->{warn} },
-"Unable to determine obs tstop; could not check for dither changes during obs\n";
-    }
-    else {
-        foreach my $dither (reverse @{$dthr}) {
-            if ($dither->{time} < $obs_tstop) {
-                $guide_dither->{ampl_p_max} =
-                  max(($dither->{ampl_p}, $guide_dither->{ampl_p_max}));
-                $guide_dither->{ampl_y_max} =
-                  max(($dither->{ampl_y}, $guide_dither->{ampl_y_max}));
-            }
-            if (   $dither->{time} > ($obs_tstart + $obs_beg_pad)
-                && $dither->{time} <= $obs_tstop - $obs_end_pad)
-            {
-                push @{ $self->{warn} },
-                  "Dither commanding at $dither->{time}.  During observation.\n";
-            }
-            if ($dither->{time} < $obs_tstart) {
-                last;
-            }
-        }
-    }
 
     # Save these to self for use by any checks outside this method.
     $self->{dither_acq} = $acq_dither;
@@ -714,6 +687,35 @@ sub check_dither {
             # which is greater than the 3 minutes used in the "no dither changes
             # during observation check below
             $obs_end_pad = 5.5 * 60;
+        }
+    }
+
+    # Check for dither changes during the observation.  This needs the updated obs_end_pad
+    # from the large dither checks above.
+    # This also updates the maximum amplitude for any observation that has dither
+    # changes.
+    # ACA-003
+    if (not defined $obs_tstop) {
+        push @{ $self->{warn} },
+"Unable to determine obs tstop; could not check for dither changes during obs\n";
+    }
+    else {
+        foreach my $dither (reverse @{$dthr}) {
+            if ($dither->{time} < $obs_tstop) {
+                $guide_dither->{ampl_p_max} =
+                  max(($dither->{ampl_p}, $guide_dither->{ampl_p_max}));
+                $guide_dither->{ampl_y_max} =
+                  max(($dither->{ampl_y}, $guide_dither->{ampl_y_max}));
+            }
+            if (   $dither->{time} > ($obs_tstart + $obs_beg_pad)
+                && $dither->{time} <= $obs_tstop - $obs_end_pad)
+            {
+                push @{ $self->{warn} },
+                  "Dither commanding at $dither->{time}.  During observation.\n";
+            }
+            if ($dither->{time} < $obs_tstart) {
+                last;
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Move large dither check before dither-in-obs check again.

This fixes a bug I introduced in #452 .  When I moved the check for "dither during an observation" before the "is this a large dither" block of code, the code to set obs_end_pad differently for large dither observations was then set to run after the check that uses it. 


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
(ska3-latest) jeanconn-fido> pytest
================================================================== test session starts ==================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 14 items                                                                                                                                      

starcheck/tests/test_state_checks.py .............                                                                                                [ 92%]
starcheck/tests/test_utils.py .                                                                                                                   [100%]

================================================================== 14 passed in 10.04s ==================================================================
(ska3-latest) jeanconn-fido> git rev-parse HEAD
465cc954cffccdde3418b6d5221425d28cc9fef2
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Regression testing set for this PR covers functional testing by including the addition of a week, DEC1624A, that includes a big dither observation.

The outputs show correctly that the spurious CRITICAL warning about dither changes during an observation have been removed from the big dither observations in that week.
```
->> CRITICAL: Dither commanding at 850967361.066.  During observation.
->> CRITICAL: Dither commanding at 850967362.066.  During observation.
 >> CAUTION : Non-standard dither
 >> CAUTION : [7] Guide sum mag diff from agasc mag   0.06257
 >> CAUTION : [9] Guide sum mag diff from agasc mag   0.04622
```

Full set of recent weeks and some "interesting" loads with regard to dither is at

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-pr453/

