### PR TITLE
Allow guide count of 3.5 with creep-away

### DIFF
--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2923,7 +2923,7 @@ sub check_guide_count {
         push @{ $self->{warn} }, "Guide count of $guide_count < $min_num_gui.\n";
     }
 
-    if (($creep_away) & ($guide_count < 4.0) & ($guide_count >= 3.5)) {
+    if (($self->{obsid} < 38000) & ($creep_away) & ($guide_count < 4.0) & ($guide_count >= 3.5)) {
         push @{ $self->{yellow_warn} },
           "Guide count of $guide_count < 4.0 but uses creep-away\n";
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2923,7 +2923,7 @@ sub check_guide_count {
         push @{ $self->{warn} }, "Guide count of $guide_count < $min_num_gui.\n";
     }
 
-    if (($self->{obsid} < 38000) & ($creep_away) & ($guide_count < 4.0) & ($guide_count >= 3.5)) {
+    if (($self->{obsid} < 38000) && ($creep_away) && ($guide_count < 4.0) && ($guide_count >= 3.5)) {
         push @{ $self->{yellow_warn} },
           "Guide count of $guide_count < 4.0 but uses creep-away\n";
     }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -582,6 +582,19 @@ sub set_star_catalog {
 }
 
 #############################################################################################
+sub get_creep_status{
+#############################################################################################
+    my $self = shift;
+    my $targ_cmd = find_command($self, "MP_TARGQUAT", -1);
+    my $man_angle_next_data = call_python("state_checks.get_obs_man_angle_next",
+                [ $targ_cmd->{tstop}, $self->{backstop} ]);
+    # Round the angle_next to 1 decimal place
+    my $angle_next = sprintf("%.1f", $man_angle_next_data->{"angle"});
+    my $creep_away = ($angle_next < 3.0);
+    return $creep_away;
+}
+
+#############################################################################################
 sub check_dither {
 #############################################################################################
     my $self = shift;
@@ -697,20 +710,13 @@ sub check_dither {
         }
     }
 
-    my $targ_cmd = find_command($self, "MP_TARGQUAT", -1);
-    my $man_angle_next_data = call_python("state_checks.get_obs_man_angle_next",
-                [ $targ_cmd->{tstop}, $self->{backstop} ]);
-
 
     # Add a check that for small or zero dither amplitudes, that creep-away is used.
     # The idea is that dynamic background is less effective for small or zero dither
     # and such observations could end in larger roll errors.  Check added in PR #452.
     # Operationally, we also do not expect to use, for example, 4x4 dither, so this
     # adds a CAUTION for unexpected small dither patterns.
-
-    # Round the angle_next to 1 decimal place
-    my $angle_next = sprintf("%.1f", $man_angle_next_data->{"angle"});
-    my $creep_away = ($angle_next < 3.0);
+    my $creep_away = $self->get_creep_status();
     my $no_dither = (($guide_dither->{state} eq 'DISA')
             or (($guide_dither->{ampl_y_int} == 0) and ($guide_dither->{ampl_p_int}== 0)));
     my $small_dither = (($guide_dither->{ampl_y_int} < 8) and ($guide_dither->{ampl_p_int} < 8)
@@ -2905,12 +2911,21 @@ sub check_guide_count {
         "Dither disabled or 0 - dynamic background bonus disabled for guide count.\n";
     }
 
+    my $creep_away = $self->get_creep_status();
+
     my $guide_count = $self->count_guide_stars($dyn_bgd);
 
-    my $min_num_gui = ($self->{obsid} >= 38000) ? 6.0 : 4.0;
+    # If obsid >= 38000, min guide count is 6.0
+    # If an OR, the required number is 3.5 if creep away else 4.0
+    my $min_num_gui = ($self->{obsid} >= 38000) ? 6.0 : ($creep_away ? 3.5 : 4.0);
 
     if ($guide_count < $min_num_gui) {
         push @{ $self->{warn} }, "Guide count of $guide_count < $min_num_gui.\n";
+    }
+
+    if (($creep_away) & ($guide_count < 4.0) & ($guide_count >= 3.5)) {
+        push @{ $self->{yellow_warn} },
+          "Guide count of $guide_count < 4.0 but uses creep-away\n";
     }
 
     # Also save the guide count in the figure_of_merit

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -822,7 +822,7 @@ for my $obs_idx (0 .. $#obsid_id) {
 
             my $creep_away = $obs{$obsid}->get_creep_status();
 
-            # minumum requirements for fractional guide star count for ERs and ORs
+            # minimum requirements for fractional guide star count for ERs and ORs
             my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000) ? 6.0 : ($creep_away ? 3.5 : 4.0);
 
             # Use the acq prob model values saved in figure_of_merit for the expected

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -823,7 +823,7 @@ for my $obs_idx (0 .. $#obsid_id) {
             my $creep_away = $obs{$obsid}->get_creep_status();
 
             # minumum requirements for fractional guide star count for ERs and ORs
-            my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000) ? 6.0 : ($creep_away ? 3.0 : 4.0);
+            my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000) ? 6.0 : ($creep_away ? 3.5 : 4.0);
 
             # Use the acq prob model values saved in figure_of_merit for the expected
             # number of acq stars and a bad overall probability.  figure_of_merit isn't

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -820,8 +820,10 @@ for my $obs_idx (0 .. $#obsid_id) {
         if (defined $cat) {
             my $guide_count = $obs{$obsid}->{figure_of_merit}->{guide_count};
 
+            my $creep_away = $obs{$obsid}->get_creep_status();
+
             # minumum requirements for fractional guide star count for ERs and ORs
-            my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000) ? 6.0 : 4.0;
+            my $min_num_gui = ($obs{$obsid}->{obsid} >= 38000) ? 6.0 : ($creep_away ? 3.0 : 4.0);
 
             # Use the acq prob model values saved in figure_of_merit for the expected
             # number of acq stars and a bad overall probability.  figure_of_merit isn't


### PR DESCRIPTION
## Description

Allow guide count of 3.5 with creep-away to be consistent with current requirements.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #459 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(latest) flame:starcheck jean$ pytest
======================================================================= test session starts ========================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 14 items                                                                                                                                                 

starcheck/tests/test_state_checks.py .............                                                                                                           [ 92%]
starcheck/tests/test_utils.py .                                                                                                                              [100%]

======================================================================== 14 passed in 4.41s ========================================================================
(latest) flame:starcheck jean$ git rev-parse HEAD
68c559f5533db722ae79ca5e6712ff6a6558d6cc
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Rerun of DEC0125A shows the new statement "Guide count of 3.5 < 4.0 but uses creep-away"

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/pr460/dec0125a_test.html#obsid29956

And the critical from flight is gone.

https://icxc.cfa.harvard.edu/mp/mplogs/2025/DEC0125/oflsa/starcheck.html#obsid29956