### PR TITLE
Do checks for optically bright planets

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -10,6 +10,7 @@ extend-exclude = [
 # incrementally fixing code to adhere to these rules, but for practical purposes they
 # can be ignored by uncommenting each one. You can also add to this list as needed.
 lint.extend-ignore = [
+  "PLR0917", # Too many positional arguments
   # "B905", # `zip()` without an explicit `strict=` parameter
   # "PLC1901", # compare-to-empty-string
   # "PLR0911", # Too many returns

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1030,6 +1030,25 @@ sub check_for_srdcs {
 }
 
 #############################################################################################
+sub check_bright_objects {
+#############################################################################################
+    my $self = shift;
+    # pass the proseco parameters do this check in Python
+    my $bright_data = call_python("utils.check_bright_objects",
+                [ $self->{'proseco_args'} ]);
+    #use Data::Dumper;
+    #print Dumper $bright_data;
+    for my $warn_type (qw(warn fyi orange_warn yellow_warn)) {
+        if (exists $bright_data->{$warn_type}) {
+            for my $warn (@{ $bright_data->{$warn_type} }) {
+                push @{ $self->{$warn_type} }, $warn;
+            }
+        }
+    }
+}
+
+
+#############################################################################################
 sub check_sim_position {
 #############################################################################################
     my $self = shift;
@@ -3120,6 +3139,8 @@ sub proseco_args {
     %proseco_args = (
         obsid => $self->{obsid},
         date => $targ_cmd->{stop_date},
+        duration => $self->{obs_tstop} - $self->{obs_tstart},
+        target_name => ($self->{TARGET_NAME}) ? $self->{TARGET_NAME} : $self->{SS_OBJECT},
         att => [
             0 + $targ_cmd->{q1},
             0 + $targ_cmd->{q2},

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -316,9 +316,11 @@ sub set_maneuver {
     my $found;
 
     my $dot_obsid = $self->{dot_obsid};
-    # If date before "2020", get the ER obsids from the processing summary
-    # If the $dot_obsid does not begin with a number
-    if ($dot_obsid !~ /^\d/ && ($self->{date} lt '2020:001:00:00:00.000')) {
+    # If the date is before ORViewer-DOT (promoted end of August 2017), get the ER obsids
+    # from the processing summary if the $dot_obsid does not begin with a number
+    # The last command from a pre-ORViewer-DOT looks to be 2017:240 so this is padded
+    # by a few days.
+    if ($dot_obsid !~ /^\d/ && ($self->{date} lt '2017:250:00:00:00.000')) {
     # The processing summary has lines that look like this
     # 'P080200   CAL       2017:013:03:00:49.827  2017:013:03:00:59.827  000:00:00:10.000 OBSID = 50385 {Perigee Attitude}
     # For each line like that, I want to extract the obsid as the up to 5 digit number after OBSID and I

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1068,29 +1068,25 @@ sub check_planets{
         $self->{planet_full_mitigation} = $bright_data->{planet_full_mitigation} ? 1 : 0;
     }
 
+    # Get an ordered list of star IDs from the catalog for easy lookup.
+    my @cat_star_ids = ();
+    if (defined $c) {
+        for my $i (1 .. 16) {
+            if ($c->{"TYPE$i"} ne 'NUL') {
+                push @cat_star_ids, ($c->{"GS_ID$i"} // '---');
+            }
+        }
+    }
+
     for my $warn_type (qw(warn fyi orange_warn yellow_warn)) {
         if (exists $bright_data->{$warn_type}) {
             for my $warn (@{ $bright_data->{$warn_type} }) {
-                # If the warning has an idx in it and an id, update the text to match the starcheck
-                # version of the catalog
-                if ($warn =~ /idx (\d+) id (\d+)/) {
+                # If the warning has an 'idx', replace it with the actual star ID.
+                if ($warn =~ /idx (\d+)/) {
                     my $idx = $1;
-                    my $star_id = '---';
-                    if (defined $c) {
-                        for my $i (1 .. 16) {
-                            if ($c->{"TYPE$i"} ne 'NUL') {
-                                $idx--;
-                                if ($idx == 0) {
-                                    $star_id = $c->{"GS_ID$i"} if (defined $c->{"GS_ID$i"});
-                                    last;
-                                }
-                            }
-                        }
-                        $star_id = $c->{"GS_ID$idx"} if (defined $c->{"GS_ID$idx"});
-                    }
-                    $warn =~ s/IDX=$idx/STAR_ID=$star_id/;
+                    my $star_id = $cat_star_ids[$idx] // '---';
+                    $warn =~ s/idx \d+/STAR_ID=$star_id/;
                 }
-
                 push @{ $self->{$warn_type} }, "$warn\n";
             }
         }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2755,7 +2755,7 @@ sub identify_stars {
             # Confirm that the agasc magnitude matches the guide star summary magnitude
             my $gs_mag = $c->{"GS_MAG$i"};
             my $dmag = abs($star->{mag_aca} - $gs_mag);
-            if ($dmag > 0.5) {
+            if ($dmag > 0.01) {
                 push @{ $self->{yellow_warn} },
                   sprintf("[%d] Guide sum mag diff from agasc mag %9.5f\n", $i, $dmag);
             }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1058,10 +1058,19 @@ sub check_planets{
 #############################################################################################
     my $self = shift;
     my $c = find_command($self, 'MP_STARCAT');
-    # Skip this check if the
-    # pass the proseco parameters do this check in Python
+    $self->{planet_full_mitigation} = 0;
     my $bright_data = call_python("utils.run_sparkles_planet_checks",
                 [ $self->{'proseco_args'} ]);
+
+    if (exists $bright_data->{fyi}) {
+        for my $msg (@{ $bright_data->{fyi} }) {
+            if ($msg =~ /Ran Full OBO Mitigation checks\./) {
+                $self->{planet_full_mitigation} = 1;
+                last;
+            }
+        }
+    }
+
     for my $warn_type (qw(warn fyi orange_warn yellow_warn)) {
         if (exists $bright_data->{$warn_type}) {
             for my $warn (@{ $bright_data->{$warn_type} }) {
@@ -1172,14 +1181,7 @@ sub check_star_catalog {
     my $is_er = ($self->{obsid} =~ /^\d+$/ && $self->{obsid} >= $ER_MIN_OBSID);
     my $min_guide = $is_science ? 5 : 6;    # Minimum number of each object type
     my $min_acq = $is_science ? 4 : 5;
-    my $target_name = "";
-    if (defined $self->{TARGET_NAME}) {
-        $target_name = $self->{TARGET_NAME};
-    }
-    if (defined $self->{SS_OBJECT}) {
-        $target_name = $self->{SS_OBJECT};
-    }
-    my $min_fid = ($target_name =~ /Venus/) ? 2 : 3;
+    my $min_fid = ($self->{planet_full_mitigation}) ? 2 : 3;
     ########################################################################
 
     my @warn = ();
@@ -1227,7 +1229,6 @@ sub check_star_catalog {
 
     # Global checks on star/fid numbers
     # ACA-005 ACA-006 ACA-007 ACA-008 ACA-044
-    print STDERR "$target_name\n";
     push @warn, "Too Few Fid Lights\n" if (@{ $self->{fid} } < $min_fid && $is_science);
     push @warn, "Too Many Fid Lights\n"
       if ( (@{ $self->{fid} } > 0 && $is_er)

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -2755,7 +2755,7 @@ sub identify_stars {
             # Confirm that the agasc magnitude matches the guide star summary magnitude
             my $gs_mag = $c->{"GS_MAG$i"};
             my $dmag = abs($star->{mag_aca} - $gs_mag);
-            if ($dmag > 0.01) {
+            if ($dmag > 0.5) {
                 push @{ $self->{yellow_warn} },
                   sprintf("[%d] Guide sum mag diff from agasc mag %9.5f\n", $i, $dmag);
             }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1053,7 +1053,6 @@ sub check_for_srdcs {
 sub check_planets{
 #############################################################################################
     my $self = shift;
-    my $c = find_command($self, 'MP_STARCAT');
     $self->{planet_full_mitigation} = 0;
     my $bright_data = call_python("utils.run_sparkles_planet_checks",
                 [ $self->{'proseco_args'} ]);
@@ -1062,24 +1061,14 @@ sub check_planets{
         $self->{planet_full_mitigation} = $bright_data->{planet_full_mitigation} ? 1 : 0;
     }
 
-    # Get an ordered list of star IDs from the catalog for easy lookup.
-    my @cat_star_ids = ();
-    if (defined $c) {
-        for my $i (1 .. 16) {
-            if ($c->{"TYPE$i"} ne 'NUL') {
-                push @cat_star_ids, ($c->{"GS_ID$i"} // '---');
-            }
-        }
-    }
-
     for my $warn_type (qw(warn fyi orange_warn yellow_warn)) {
         if (exists $bright_data->{$warn_type}) {
             for my $warn (@{ $bright_data->{$warn_type} }) {
-                # If the warning has an 'idx', replace it with the actual star ID.
+                # Move 'idx N' to the front as a bracketed catalog index matching
+                # starcheck's [%2d] format.
                 if ($warn =~ /idx (\d+)/) {
-                    my $idx = $1;
-                    my $star_id = $cat_star_ids[$idx] // '---';
-                    $warn =~ s/idx \d+/STAR_ID=$star_id/;
+                    my $idx = $1;  # save before second substitution resets $1
+                    $warn = sprintf "[%2d] %s", $idx, $warn;
                 }
                 push @{ $self->{$warn_type} }, "$warn\n";
             }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use Ska::Starcheck::Python qw(date2time time2date call_python);
 
-use List::Util qw(min max);
+use List::Util qw(min max first);
 use Quat;
 use File::Basename;
 use POSIX qw(floor);
@@ -325,13 +325,10 @@ sub set_maneuver {
     # 'P080200   CAL       2017:013:03:00:49.827  2017:013:03:00:59.827  000:00:00:10.000 OBSID = 50385 {Perigee Attitude}
     # For each line like that, I want to extract the obsid as the up to 5 digit number after OBSID and I
     # want to extract the "dot_obsid" as the first 5 characters of the line (P0802 in this case)
-        foreach my $ps_line (@$ps) {
-            if ($ps_line =~ /^\s*(\S{5}).*OBSID\s*=\s*(\d{1,5})/) {
-                if ($1 eq $dot_obsid) {
-                    $dot_obsid = $2;
-                    last;
-                }
-            }
+    # This uses the list::util first function to find the first line that matches the $dot_obsid and has OBSID in it
+        my $ps_line = first { /^\s*\Q$dot_obsid\E.*OBSID/ } @$ps;
+        if ($ps_line && $ps_line =~ /OBSID\s*=\s*(\d{1,5})/) {
+            $dot_obsid = $1;
         }
     }
 
@@ -400,12 +397,9 @@ sub set_maneuver {
             }
 
         }
-        push @{ $self->{yellow_warn} },
-          sprintf("Did not find match in maneuvers for MP_TARGQUAT at $c->{date}\n")
-          unless ($found);
-
         unless ($found) {
-            # throw error and quit
+            push @{ $self->{yellow_warn} },
+              sprintf("Did not find match in maneuvers for MP_TARGQUAT at $c->{date}\n");
             exit(1);
         }
 

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -310,9 +310,28 @@ sub set_maneuver {
 ##################################################################################
     my $self = shift;
     my $mm = shift;
+    my $ps = shift;
     my $n = 1;
     my $c;
     my $found;
+
+    my $dot_obsid = $self->{dot_obsid};
+    # If date before "2020", get the ER obsids from the processing summary
+    # If the $dot_obsid does not begin with a number
+    if ($dot_obsid !~ /^\d/ && ($self->{date} lt '2020:001:00:00:00.000')) {
+    # The processing summary has lines that look like this
+    # 'P080200   CAL       2017:013:03:00:49.827  2017:013:03:00:59.827  000:00:00:10.000 OBSID = 50385 {Perigee Attitude}
+    # For each line like that, I want to extract the obsid as the up to 5 digit number after OBSID and I
+    # want to extract the "dot_obsid" as the first 5 characters of the line (P0802 in this case)
+        foreach my $ps_line (@$ps) {
+            if ($ps_line =~ /^\s*(\S{5}).*OBSID\s*=\s*(\d{1,5})/) {
+                if ($1 eq $dot_obsid) {
+                    $dot_obsid = $2;
+                    last;
+                }
+            }
+        }
+    }
 
     while ($c = find_command($self, "MP_TARGQUAT", $n++)) {
         $found = 0;
@@ -321,7 +340,7 @@ sub set_maneuver {
 
 # where manvr_dest is either the final_obsid of a maneuver or the eventual destination obsid
             # of a segmented maneuver
-            if (   ($manvr_obsid eq $self->{dot_obsid})
+            if (   ($manvr_obsid eq $dot_obsid)
                 && abs($m->{q1} - $c->{Q1}) < 1e-7
                 && abs($m->{q2} - $c->{Q2}) < 1e-7
                 && abs($m->{q3} - $c->{Q3}) < 1e-7)
@@ -382,6 +401,11 @@ sub set_maneuver {
         push @{ $self->{yellow_warn} },
           sprintf("Did not find match in maneuvers for MP_TARGQUAT at $c->{date}\n")
           unless ($found);
+
+        unless ($found) {
+            # throw error and quit
+            exit(1);
+        }
 
     }
 }
@@ -1030,18 +1054,38 @@ sub check_for_srdcs {
 }
 
 #############################################################################################
-sub check_bright_objects {
+sub check_planets{
 #############################################################################################
     my $self = shift;
+    my $c = find_command($self, 'MP_STARCAT');
+    # Skip this check if the
     # pass the proseco parameters do this check in Python
-    my $bright_data = call_python("utils.check_bright_objects",
+    my $bright_data = call_python("utils.run_sparkles_planet_checks",
                 [ $self->{'proseco_args'} ]);
-    #use Data::Dumper;
-    #print Dumper $bright_data;
     for my $warn_type (qw(warn fyi orange_warn yellow_warn)) {
         if (exists $bright_data->{$warn_type}) {
             for my $warn (@{ $bright_data->{$warn_type} }) {
-                push @{ $self->{$warn_type} }, $warn;
+                # If the warning has an idx in it and an id, update the text to match the starcheck
+                # version of the catalog
+                if ($warn =~ /idx (\d+) id (\d+)/) {
+                    my $idx = $1;
+                    my $star_id = '---';
+                    if (defined $c) {
+                        for my $i (1 .. 16) {
+                            if ($c->{"TYPE$i"} ne 'NUL') {
+                                $idx--;
+                                if ($idx == 0) {
+                                    $star_id = $c->{"GS_ID$i"} if (defined $c->{"GS_ID$i"});
+                                    last;
+                                }
+                            }
+                        }
+                        $star_id = $c->{"GS_ID$idx"} if (defined $c->{"GS_ID$idx"});
+                    }
+                    $warn =~ s/IDX=$idx/STAR_ID=$star_id/;
+                }
+
+                push @{ $self->{$warn_type} }, "$warn\n";
             }
         }
     }
@@ -1128,7 +1172,14 @@ sub check_star_catalog {
     my $is_er = ($self->{obsid} =~ /^\d+$/ && $self->{obsid} >= $ER_MIN_OBSID);
     my $min_guide = $is_science ? 5 : 6;    # Minimum number of each object type
     my $min_acq = $is_science ? 4 : 5;
-    my $min_fid = 3;
+    my $target_name = "";
+    if (defined $self->{TARGET_NAME}) {
+        $target_name = $self->{TARGET_NAME};
+    }
+    if (defined $self->{SS_OBJECT}) {
+        $target_name = $self->{SS_OBJECT};
+    }
+    my $min_fid = ($target_name =~ /Venus/) ? 2 : 3;
     ########################################################################
 
     my @warn = ();
@@ -1176,7 +1227,7 @@ sub check_star_catalog {
 
     # Global checks on star/fid numbers
     # ACA-005 ACA-006 ACA-007 ACA-008 ACA-044
-
+    print STDERR "$target_name\n";
     push @warn, "Too Few Fid Lights\n" if (@{ $self->{fid} } < $min_fid && $is_science);
     push @warn, "Too Many Fid Lights\n"
       if ( (@{ $self->{fid} } > 0 && $is_er)
@@ -3164,7 +3215,6 @@ sub proseco_args {
         n_fid => scalar(@fid_ids),
         acq_indexes => \@acq_indexes
     );
-
     return \%proseco_args;
 
 }

--- a/starcheck/src/lib/Ska/Starcheck/Obsid.pm
+++ b/starcheck/src/lib/Ska/Starcheck/Obsid.pm
@@ -1062,13 +1062,8 @@ sub check_planets{
     my $bright_data = call_python("utils.run_sparkles_planet_checks",
                 [ $self->{'proseco_args'} ]);
 
-    if (exists $bright_data->{fyi}) {
-        for my $msg (@{ $bright_data->{fyi} }) {
-            if ($msg =~ /Ran Full OBO Mitigation checks\./) {
-                $self->{planet_full_mitigation} = 1;
-                last;
-            }
-        }
+    if (exists $bright_data->{planet_full_mitigation}) {
+        $self->{planet_full_mitigation} = $bright_data->{planet_full_mitigation} ? 1 : 0;
     }
 
     for my $warn_type (qw(warn fyi orange_warn yellow_warn)) {

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -648,6 +648,7 @@ foreach my $obsid (@obsid_id) {
         $obs{$obsid}->check_bright_perigee($radmon);
         $obs{$obsid}->check_guide_count();
         $obs{$obsid}->check_for_srdcs(\@bs);
+        $obs{$obsid}->check_bright_objects();
     }
 
     # Make sure there is only one star catalog per obsid

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -69,6 +69,7 @@ GetOptions(
     'run_start_time=s',
     'maude!',
     'max_obsids:i',
+    'save_pkl=s',
 ) || exit(1);
 
 usage(1)
@@ -642,13 +643,17 @@ foreach my $obsid (@obsid_id) {
         # Get the args that proseco would want
         $obs{$obsid}->{'proseco_args'} = $obs{$obsid}->proseco_args();
         $obs{$obsid}->set_proseco_probs_and_check_P2();
+        $obs{$obsid}->check_planets();
         $obs{$obsid}->check_star_catalog($or{$obsid}, $par{vehicle});
         $obs{$obsid}->check_sim_position(@sim_trans) unless $par{vehicle};
         $obs{$obsid}->check_momentum_unload(\@bs);
         $obs{$obsid}->check_bright_perigee($radmon);
         $obs{$obsid}->check_guide_count();
         $obs{$obsid}->check_for_srdcs(\@bs);
-        $obs{$obsid}->check_planets();
+    }
+
+    if ($par{save_pkl}) {
+        call_python("utils.save_proseco_catalogs", [ $par{save_pkl} ]);
     }
 
     # Make sure there is only one star catalog per obsid

--- a/starcheck/src/starcheck.pl
+++ b/starcheck/src/starcheck.pl
@@ -437,7 +437,7 @@ foreach my $obsid (@obsid_id) {
     $obs{$obsid}->set_obsid(\%guidesumm);    # Commanded obsid
     $obs{$obsid}->set_target();
     $obs{$obsid}->set_star_catalog();
-    $obs{$obsid}->set_maneuver($mm);
+    $obs{$obsid}->set_maneuver($mm, \@ps);
     $obs{$obsid}->set_files(
         $STARCHECK,
         $backstop,
@@ -648,7 +648,7 @@ foreach my $obsid (@obsid_id) {
         $obs{$obsid}->check_bright_perigee($radmon);
         $obs{$obsid}->check_guide_count();
         $obs{$obsid}->check_for_srdcs(\@bs);
-        $obs{$obsid}->check_bright_objects();
+        $obs{$obsid}->check_planets();
     }
 
     # Make sure there is only one star catalog per obsid

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pickle
 
-import starcheck.utils as utils
+from starcheck import utils
 from starcheck.utils import (
     check_hot_pix,
     get_and_collect_proseco_catalog,

--- a/starcheck/tests/test_utils.py
+++ b/starcheck/tests/test_utils.py
@@ -1,4 +1,123 @@
-from starcheck.utils import check_hot_pix
+import pickle
+
+import starcheck.utils as utils
+from starcheck.utils import (
+    check_hot_pix,
+    get_and_collect_proseco_catalog,
+    get_proseco_catalog,
+    run_sparkles_planet_checks,
+    save_proseco_catalogs,
+)
+
+# Real proseco_args from obsid 28777 in JUN2325_A (HRC-I, 3 fids, 8 acq/5 guide)
+_OBS_28777_ARGS = {
+    "obsid": 28777,
+    "att": [0.142378962865, -0.842210948602, 0.4728311264, 0.216424755738],
+    "date": "2025:174:00:42:44.586",
+    "detector": "HRC-I",
+    "dither_acq": [20.0014963044938, 20.0014963044938],
+    "dither_guide": [20.0014963044938, 20.0014963044938],
+    "fid_ids": [8, 9, 10],
+    "include_halfws_acq": [160, 160, 120, 140, 100, 160, 160, 100],
+    "include_ids_acq": [
+        331222504,
+        331224640,
+        260576048,
+        331223656,
+        260571904,
+        260580432,
+        260575280,
+        260575376,
+    ],
+    "include_ids_guide": [331222504, 331224640, 260576048, 331223656, 260571904],
+    "man_angle": 122.221322321489,
+    "n_acq": 8,
+    "n_fid": 3,
+    "n_guide": 5,
+    "sim_offset": 0,
+    "t_ccd_acq": -4.72435604571444,
+    "t_ccd_guide": -4.53268231435102,
+    "duration": 20000.0,
+    "target_name": "SN 1941C",
+}
+
+
+def test_get_proseco_catalog_returns_expected_acq_stars():
+    """get_proseco_catalog returns a catalog containing all commanded acq star IDs."""
+    aca = get_proseco_catalog(**_OBS_28777_ARGS)
+    acq_ids = set(aca.acqs["id"])
+    for star_id in _OBS_28777_ARGS["include_ids_acq"]:
+        assert star_id in acq_ids
+
+
+def test_get_and_collect_proseco_catalog_accumulates():
+    """get_and_collect_proseco_catalog stores the catalog in _proseco_catalogs keyed by obsid."""
+    utils._proseco_catalogs.clear()
+    aca = get_and_collect_proseco_catalog(_OBS_28777_ARGS)
+    assert _OBS_28777_ARGS["obsid"] in utils._proseco_catalogs
+    assert utils._proseco_catalogs[_OBS_28777_ARGS["obsid"]] is aca
+    utils._proseco_catalogs.clear()
+
+
+# Venus bad case adapted from sparkles test_venus_bad (att/date where Venus is on CCD)
+_VENUS_BAD_ARGS = {
+    "obsid": 18696,
+    "att": [-0.54152552, 0.17005146, -0.10308105, 0.81682734],
+    "man_angle": 90,
+    "date": "2017:010:06:57:57.000",
+    "t_ccd_acq": -10.0,
+    "t_ccd_guide": -10.0,
+    "dither_acq": [7.9992, 7.9992],
+    "dither_guide": [7.9992, 7.9992],
+    "detector": "ACIS-I",
+    "sim_offset": 0,
+    "n_acq": 8,
+    "n_guide": 5,
+    "n_fid": 3,
+    "fid_ids": [1, 2, 3],
+    "include_ids_acq": [],
+    "include_halfws_acq": [],
+    "include_ids_guide": [],
+    "duration": 30000.0,
+    "target_name": "Venus",
+}
+
+
+def test_run_sparkles_planet_checks_venus_bad():
+    """run_sparkles_planet_checks produces critical warnings and sets planet_full_mitigation
+    for an attitude where Venus is on the CCD and mitigation requirements are not met."""
+    result = run_sparkles_planet_checks(_VENUS_BAD_ARGS)
+    assert result["planet_full_mitigation"] is True
+    assert "Need 5 guide stars on side of CCD opposite bright object." in result["warn"]
+    assert "Need 2 fid lights on side of CCD opposite bright object." in result["warn"]
+    assert "Bright object tracks too close to CCD boundary row=0." in result["warn"]
+    assert "Full mitigation OBO checks failed." in result["warn"]
+    assert "Venus on CCD. (mag -5.0 to -2.9)." in result["fyi"]
+    assert result["orange_warn"] == []
+    assert result["yellow_warn"] == []
+
+
+def test_run_sparkles_planet_checks_no_planet():
+    """run_sparkles_planet_checks returns no warnings and planet_full_mitigation False
+    for a normal observation with no nearby bright planet."""
+    result = run_sparkles_planet_checks(_OBS_28777_ARGS)
+    assert result["planet_full_mitigation"] is False
+    assert result["warn"] == []
+    assert result["orange_warn"] == []
+    assert result["yellow_warn"] == []
+
+
+def test_save_proseco_catalogs(tmp_path):
+    """save_proseco_catalogs writes _proseco_catalogs to a readable pickle file."""
+    utils._proseco_catalogs.clear()
+    get_and_collect_proseco_catalog(_OBS_28777_ARGS)
+    out_path = tmp_path / "catalogs.pkl"
+    save_proseco_catalogs(out_path)
+    assert out_path.exists()
+    with open(out_path, "rb") as f:
+        loaded = pickle.load(f)
+    assert _OBS_28777_ARGS["obsid"] in loaded
+    utils._proseco_catalogs.clear()
 
 
 def test_check_dynamic_hot_pix():

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -782,19 +782,19 @@ def check_bright_objects(proseco_args):
                         "but not on CCD\n",
                     ]
                 )
-            elif planet not in proseco_args["target_name"].lower():
-                msgs["orange_warn"].extend(
-                    [
-                        f"Bright object alert: {planet.title()} on CCD but not in target name\n"
-                    ]
-                )
+            else:
+                if planet not in proseco_args["target_name"].lower():
+                    msgs["orange_warn"].extend(
+                        [
+                            f"Bright object alert: {planet.title()} on CCD but not in target name\n"
+                        ]
+                    )
 
-            if planet in ("mars", "saturn"):
-                if len(pos) > 0:
+                if planet in ("mars", "saturn"):
                     msgs["fyi"].extend([f"Bright object: {planet.title()} on CCD\n"])
 
-            if planet == "jupiter":
-                jmsgs = run_jupiter_checks(proseco_args)
-                for key in jmsgs:
-                    msgs[key].extend(jmsgs[key])
+                if planet == "jupiter":
+                    jmsgs = run_jupiter_checks(proseco_args)
+                    for key in jmsgs:
+                        msgs[key].extend(jmsgs[key])
     return msgs

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -584,3 +584,242 @@ def vehicle_filter_backstop(backstop_file, outfile):
     ]
     # Write the filtered commands to the output file
     write_backstop(filtered_cmds, outfile)
+
+
+def check_for_planets(date0, duration, att, observer_position="earth", tol=2.25):
+    import astropy.units as u
+    from chandra_aca.planets import get_planet_angular_sep
+
+    att = Quaternion.Quat(q=att)
+
+    date0 = CxoTime(date0)
+    planets = ("venus", "mars", "jupiter", "saturn")
+    has_planet = dict.fromkeys(planets, False)
+
+    for planet in planets:
+        # First check if planet is within 2 deg of aimpoint using Earth as the
+        # reference point (without fetching Chandra ephemeris). These values are
+        # accurate to better than 0.25 deg.
+        sep = get_planet_angular_sep(
+            planet,
+            ra=att.ra,
+            dec=att.dec,
+            time=date0 + ([0, 0.5, 1] * u.s) * duration,
+            observer_position=observer_position,
+        )
+        if np.all(sep > tol):
+            continue
+
+        has_planet[planet] = True
+
+    return has_planet
+
+
+class PlanetPositionTable(Table):
+    @classmethod
+    def empty(cls):
+        return cls({"time": [], "row": [], "col": []})
+
+
+import astropy.units as u
+from cxotime import CxoTimeLike
+from Quaternion import QuatLike
+
+
+# This is a modified version of get_jupiter_position from proseco
+def get_planet_position(
+    planet: str,
+    date: CxoTimeLike,
+    duration: float,
+    att: QuatLike,
+) -> PlanetPositionTable:
+    """
+    Get the position of planet on the ACA CCD.
+
+    Parameters
+    ----------
+    planet : str
+        The planet name. Supports
+    date : CxoTimeLike
+        The start date of the observation (acquisition time)
+    duration : float
+        The duration of the observation in seconds.
+    att : Quaternion or Quat-compatible
+        The attitude Quaternion.
+
+    Returns
+    -------
+    PlanetPositionTable
+        A table with columns 'time', 'row', 'col' for the times when Jupiter
+        is on the CCD. If Jupiter is never on the CCD this is a table with zero rows.
+    """
+    date0 = CxoTime(date)
+    att = Quaternion.Quat(att)
+    # dates is a 1-d array with a minimum of 2 points (the end points)
+    dates = CxoTime.linspace(date0, date0 + duration * u.s, step_max=1000 * u.s)
+    times = dates.secs
+
+    from cheta.comps import ephem_stk
+
+    chandra_ephem = ephem_stk.get_ephemeris_stk(start=dates[0], stop=dates[-1])
+
+    # Get Jupiter positions using chandra_aca.planets
+    ephem = {
+        key: np.interp(times, chandra_ephem["time"], chandra_ephem[key])
+        for key in ["x", "y", "z"]
+    }
+    # shape (len(dates), 3), units km
+    from chandra_aca import planets
+
+    pos_earth = planets.get_planet_barycentric("earth", dates)
+
+    chandra_eci = np.array(
+        [
+            ephem["x"] / 1000,  # convert m from get_ephemeris_stk to km,
+            ephem["y"] / 1000,
+            ephem["z"] / 1000,
+        ]
+    ).transpose()
+    eci = planets.get_planet_eci(planet, dates, pos_observer=pos_earth + chandra_eci)
+
+    from chandra_aca.transform import eci_to_radec, radec_to_yagzag, yagzag_to_pixels
+
+    # Convert ECI position to RA, Dec => yag, zag => row, col
+    ra, dec = eci_to_radec(eci)
+    yag, zag = radec_to_yagzag(ra, dec, att)
+    row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
+
+    # Row/col limit in pixels to check for bright object
+    ccd_limit = 512
+
+    # Limit data to entries on the CCD
+    ok = (np.abs(row) <= ccd_limit) & (np.abs(col) <= ccd_limit)
+    out = PlanetPositionTable(
+        {
+            "time": times[ok],
+            "row": row[ok],
+            "col": col[ok],
+        }
+    )
+    return out
+
+
+def get_proseco_catalog(**kw):
+    # Note that the fid ids in starcheck are 1-6
+    # ACIS, 7-10 HRC-I 11-14 HRC-S.  Proseco just uses indexes 1-6 so
+    # subtract off the offsets.
+    fid_ids = np.array(kw["fid_ids"])
+    if kw["detector"] == "HRC-I":
+        fid_offset = 6
+    elif kw["detector"] == "HRC-S":
+        fid_offset = 10
+    else:
+        fid_offset = 0
+    fid_ids -= fid_offset
+
+    args = {
+        "obsid": int(kw["obsid"]),
+        "att": Quaternion.normalize(kw["att"]),
+        "duration": kw["duration"],
+        "target_name": kw["target_name"],
+        "date": kw["date"],
+        "n_acq": kw["n_acq"],
+        "n_guide": kw["n_guide"],
+        "man_angle": kw["man_angle"],
+        "t_ccd_acq": kw["t_ccd_acq"],
+        "t_ccd_guide": kw["t_ccd_guide"],
+        "dither_acq": ACABox(kw["dither_acq"]),
+        "dither_guide": ACABox(kw["dither_guide"]),
+        "include_ids_acq": kw["include_ids_acq"],
+        "include_halfws_acq": kw["include_halfws_acq"],
+        "detector": kw["detector"],
+        "sim_offset": kw["sim_offset"],
+        "include_ids_guide": kw["include_ids_guide"],
+        "include_ids_fid": list(fid_ids),
+        "n_fid": len(kw["fid_ids"]),
+        "focus_offset": 0,
+    }
+    if "monitors" in kw:
+        args["monitors"] = kw["monitors"]
+    aca = get_aca_catalog(**args)
+    return aca
+
+
+def run_jupiter_checks(proseco_args):
+    proseco_args["target_name"] = "Jupiter"
+    aca = get_proseco_catalog(**proseco_args)
+    acar = aca.get_review_table()
+    from sparkles.checks import check_run_jupiter_checks
+    from sparkles.messages import MessagesList
+
+    msgs = MessagesList(check_run_jupiter_checks(acar))
+    return {
+        "warn": [w["text"] for w in msgs == "critical"],
+        "orange_warn": [w["text"] for w in msgs == "caution"],
+        "yellow_warn": [w["text"] for w in msgs == "warning"],
+        "fyi": [w["text"] for w in msgs == "info"],
+    }
+
+
+def check_bright_objects(proseco_args):
+    # Do a rough check with Earth ephemeris and padded tolerance of 2.25 deg
+    has_planet = check_for_planets(
+        proseco_args["date"],
+        proseco_args["duration"],
+        proseco_args["att"],
+        observer_position="earth",
+        tol=2.25,
+    )
+    if not any(has_planet.values()):
+        return {}
+
+    # Do the more detailed check with chandra ephemeris
+    has_planet = check_for_planets(
+        proseco_args["date"],
+        proseco_args["duration"],
+        proseco_args["att"],
+        observer_position="chandra",
+        tol=2,
+    )
+
+    import collections
+
+    msgs = collections.defaultdict(list)
+
+    if has_planet["venus"]:
+        msgs["warn"].extend(
+            ["Bright object alert: Venus within 2 deg of ACA center\n"]
+        )
+
+    for planet in ("mars", "jupiter", "saturn"):
+        if has_planet[planet]:
+            pos = get_planet_position(
+                planet,
+                proseco_args["date"],
+                proseco_args["duration"],
+                proseco_args["att"],
+            )
+
+            if len(pos) == 0:
+                msgs["warn"].extend(
+                    [
+                        f"Bright object alert: {planet.title()} within 2 deg of ACA center, ",
+                        "but not on CCD\n",
+                    ]
+                )
+            elif planet not in proseco_args["target_name"].lower():
+                msgs["orange_warn"].extend(
+                    [
+                        f"Bright object alert: {planet.title()} on CCD but not in target name\n"
+                    ]
+                )
+
+            if planet in ("mars", "saturn"):
+                if len(pos) > 0:
+                    msgs["fyi"].extend([f"Bright object: {planet.title()} on CCD\n"])
+
+            if planet == "jupiter":
+                jmsgs = run_jupiter_checks(proseco_args)
+                for key in jmsgs:
+                    msgs[key].extend(jmsgs[key])
+    return msgs

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 import os
 import warnings
@@ -587,14 +586,6 @@ def vehicle_filter_backstop(backstop_file, outfile):
     write_backstop(filtered_cmds, outfile)
 
 
-
-import astropy.units as u
-from cxotime import CxoTimeLike
-from Quaternion import QuatLike
-from chandra_aca.planets import (get_planet_chandra_ccd_position, get_planet_mag_states)
-
-
-
 def get_proseco_catalog(**kw):
     # Note that the fid ids in starcheck are 1-6
     # ACIS, 7-10 HRC-I 11-14 HRC-S.  Proseco just uses indexes 1-6 so
@@ -633,21 +624,25 @@ def get_proseco_catalog(**kw):
     if "monitors" in kw:
         args["monitors"] = kw["monitors"]
     aca = get_aca_catalog(**args)
-    # Let's write this out to a pickle file for debugging
-
-    with open(f"aca_debug_{args['obsid']}.pkl", "wb") as f:
-        import pickle
-        pickle.dump(aca, f)
     return aca
 
 
+# Module-level accumulator for proseco catalogs; populated by get_and_collect_proseco_catalog.
+_proseco_catalogs = {}
+
+
+def get_and_collect_proseco_catalog(proseco_args):
+    """Build a proseco catalog, accumulate it by obsid, and return it."""
+    aca = get_proseco_catalog(**proseco_args)
+    _proseco_catalogs[proseco_args["obsid"]] = aca
+    return aca
 
 
 def run_sparkles_planet_checks(proseco_args):
     from sparkles.checks import check_planets
     from sparkles.messages import MessagesList
 
-    aca = get_proseco_catalog(**proseco_args)
+    aca = get_and_collect_proseco_catalog(proseco_args)
     acar = aca.get_review_table()
 
     msgs = MessagesList(check_planets(acar))
@@ -657,4 +652,11 @@ def run_sparkles_planet_checks(proseco_args):
         "yellow_warn": [w["text"] for w in msgs == "warning"],
         "fyi": [w["text"] for w in msgs == "info"],
     }
+
+
+def save_proseco_catalogs(path):
+    import pickle
+
+    with open(path, "wb") as f:
+        pickle.dump(_proseco_catalogs, f)
 

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pickle
 import warnings
 from pathlib import Path
 
@@ -586,58 +587,43 @@ def vehicle_filter_backstop(backstop_file, outfile):
     write_backstop(filtered_cmds, outfile)
 
 
+# Fiducial light ID offsets for different detectors, used to translate
+# starcheck global IDs to proseco per-detector IDs.
+FID_OFFSET = {"HRC-I": 6, "HRC-S": 10, "ACIS-I": 0, "ACIS-S": 0}
+
+
 def get_proseco_catalog(**kw):
     """
     Build a full proseco ACA catalog from starcheck observation parameters.
 
     Translates fid light IDs from starcheck's global numbering (ACIS 1-6,
     HRC-I 7-10, HRC-S 11-14) to proseco's per-detector numbering by
-    subtracting detector-specific offsets (HRC-I: 6, HRC-S: 10, ACIS: 0).
+    subtracting detector-specific offsets.
 
     :param **kw: keyword arguments matching the proseco_args structure from
-        Obsid.proseco_args(). Required keys: obsid, att, duration,
-        target_name, date, n_acq, n_guide, man_angle, t_ccd_acq, t_ccd_guide,
-        dither_acq, dither_guide, include_ids_acq, include_halfws_acq,
-        detector, sim_offset, include_ids_guide, fid_ids. An optional
-        'monitors' key is passed through to get_aca_catalog.
+        Obsid.proseco_args().
     :returns: proseco ACATable catalog
     """
-    # Note that the fid ids in starcheck are 1-6
-    # ACIS, 7-10 HRC-I 11-14 HRC-S.  Proseco just uses indexes 1-6 so
-    # subtract off the offsets.
-    fid_ids = np.array(kw["fid_ids"])
-    if kw["detector"] == "HRC-I":
-        fid_offset = 6
-    elif kw["detector"] == "HRC-S":
-        fid_offset = 10
-    else:
-        fid_offset = 0
-    fid_ids -= fid_offset
+    args = kw.copy()
 
-    args = {
-        "obsid": int(kw["obsid"]),
-        "att": Quaternion.normalize(kw["att"]),
-        "duration": kw["duration"],
-        "target_name": kw["target_name"],
-        "date": kw["date"],
-        "n_acq": kw["n_acq"],
-        "n_guide": kw["n_guide"],
-        "man_angle": kw["man_angle"],
-        "t_ccd_acq": kw["t_ccd_acq"],
-        "t_ccd_guide": kw["t_ccd_guide"],
-        "dither_acq": ACABox(kw["dither_acq"]),
-        "dither_guide": ACABox(kw["dither_guide"]),
-        "include_ids_acq": kw["include_ids_acq"],
-        "include_halfws_acq": kw["include_halfws_acq"],
-        "detector": kw["detector"],
-        "sim_offset": kw["sim_offset"],
-        "include_ids_guide": kw["include_ids_guide"],
-        "include_ids_fid": list(fid_ids),
-        "n_fid": len(kw["fid_ids"]),
-        "focus_offset": 0,
-    }
-    if "monitors" in kw:
-        args["monitors"] = kw["monitors"]
+    # Translate fid_ids from starcheck global to proseco per-detector.
+    fid_offset = FID_OFFSET.get(args["detector"], 0)
+    fid_ids = np.array(args["fid_ids"]) - fid_offset
+    args["include_ids_fid"] = list(fid_ids)
+    args["n_fid"] = len(fid_ids)
+    del args["fid_ids"]  # Remove original starcheck-style fid_ids
+
+    # Update args with required types and values for proseco
+    args.update(
+        {
+            "obsid": int(args["obsid"]),
+            "att": Quaternion.normalize(args["att"]),
+            "dither_acq": ACABox(args["dither_acq"]),
+            "dither_guide": ACABox(args["dither_guide"]),
+            "focus_offset": 0,
+        }
+    )
+
     aca = get_aca_catalog(**args)
     return aca
 
@@ -702,7 +688,5 @@ def save_proseco_catalogs(path):
 
     :param path: file path to write the pickle
     """
-    import pickle
-
     with open(path, "wb") as f:
         pickle.dump(_proseco_catalogs, f)

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -604,25 +604,48 @@ def get_proseco_catalog(**kw):
         Obsid.proseco_args().
     :returns: proseco ACATable catalog
     """
-    args = kw.copy()
+    # Define the set of valid arguments for proseco.get_aca_catalog
+    PROSECO_ARGS = {
+        "obsid",
+        "att",
+        "duration",
+        "target_name",
+        "date",
+        "n_acq",
+        "n_guide",
+        "man_angle",
+        "t_ccd_acq",
+        "t_ccd_guide",
+        "dither_acq",
+        "dither_guide",
+        "include_ids_acq",
+        "include_halfws_acq",
+        "detector",
+        "sim_offset",
+        "include_ids_guide",
+        "include_ids_fid",
+        "n_fid",
+        "focus_offset",
+        "monitors",
+    }
 
-    # Translate fid_ids from starcheck global to proseco per-detector.
-    fid_offset = FID_OFFSET.get(args["detector"], 0)
-    fid_ids = np.array(args["fid_ids"]) - fid_offset
+    # Create the args dict by picking only the valid keys from kwargs
+    args = {key: kw[key] for key in PROSECO_ARGS if key in kw}
+
+    # --- Handle transformations and required arguments ---
+
+    # Translate fid_ids from starcheck global to proseco per-detector
+    fid_offset = FID_OFFSET.get(kw["detector"], 0)
+    fid_ids = np.array(kw["fid_ids"]) - fid_offset
     args["include_ids_fid"] = list(fid_ids)
     args["n_fid"] = len(fid_ids)
-    del args["fid_ids"]  # Remove original starcheck-style fid_ids
 
-    # Update args with required types and values for proseco
-    args.update(
-        {
-            "obsid": int(args["obsid"]),
-            "att": Quaternion.normalize(args["att"]),
-            "dither_acq": ACABox(args["dither_acq"]),
-            "dither_guide": ACABox(args["dither_guide"]),
-            "focus_offset": 0,
-        }
-    )
+    # Ensure required types and values
+    args["obsid"] = int(kw["obsid"])
+    args["att"] = Quaternion.normalize(kw["att"])
+    args["dither_acq"] = ACABox(kw["dither_acq"])
+    args["dither_guide"] = ACABox(kw["dither_guide"])
+    args["focus_offset"] = 0
 
     aca = get_aca_catalog(**args)
     return aca

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -639,18 +639,19 @@ def get_and_collect_proseco_catalog(proseco_args):
 
 
 def run_sparkles_planet_checks(proseco_args):
-    from sparkles.checks import check_planets
+    from sparkles.checks import get_planet_check_data
     from sparkles.messages import MessagesList
 
     aca = get_and_collect_proseco_catalog(proseco_args)
     acar = aca.get_review_table()
-
-    msgs = MessagesList(check_planets(acar))
+    planet_check_data = get_planet_check_data(acar)
+    msgs = MessagesList(planet_check_data["messages"])
     return {
         "warn": [w["text"] for w in msgs == "critical"],
         "orange_warn": [w["text"] for w in msgs == "caution"],
         "yellow_warn": [w["text"] for w in msgs == "warning"],
         "fyi": [w["text"] for w in msgs == "info"],
+        "planet_full_mitigation": planet_check_data["planet_full_mitigation"],
     }
 
 

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -587,6 +587,21 @@ def vehicle_filter_backstop(backstop_file, outfile):
 
 
 def get_proseco_catalog(**kw):
+    """
+    Build a full proseco ACA catalog from starcheck observation parameters.
+
+    Translates fid light IDs from starcheck's global numbering (ACIS 1-6,
+    HRC-I 7-10, HRC-S 11-14) to proseco's per-detector numbering by
+    subtracting detector-specific offsets (HRC-I: 6, HRC-S: 10, ACIS: 0).
+
+    :param **kw: keyword arguments matching the proseco_args structure from
+        Obsid.proseco_args(). Required keys: obsid, att, duration,
+        target_name, date, n_acq, n_guide, man_angle, t_ccd_acq, t_ccd_guide,
+        dither_acq, dither_guide, include_ids_acq, include_halfws_acq,
+        detector, sim_offset, include_ids_guide, fid_ids. An optional
+        'monitors' key is passed through to get_aca_catalog.
+    :returns: proseco ACATable catalog
+    """
     # Note that the fid ids in starcheck are 1-6
     # ACIS, 7-10 HRC-I 11-14 HRC-S.  Proseco just uses indexes 1-6 so
     # subtract off the offsets.
@@ -632,13 +647,35 @@ _proseco_catalogs = {}
 
 
 def get_and_collect_proseco_catalog(proseco_args):
-    """Build a proseco catalog, accumulate it by obsid, and return it."""
+    """
+    Build a proseco catalog, store it in _proseco_catalogs by obsid, and return it.
+
+    :param proseco_args: dict of observation parameters (obsid, att, etc.)
+    :returns: proseco ACATable catalog
+    """
     aca = get_proseco_catalog(**proseco_args)
     _proseco_catalogs[proseco_args["obsid"]] = aca
     return aca
 
 
 def run_sparkles_planet_checks(proseco_args):
+    """
+    Run sparkles planet checks and return categorized warnings.
+
+    Builds a proseco catalog for the observation, runs sparkles planet checks,
+    and returns warnings sorted by severity. Also accumulates the catalog in
+    _proseco_catalogs.
+
+    :param proseco_args: dict of observation parameters (same format as
+        Obsid.proseco_args() in the Perl code)
+    :returns: dict with keys:
+        - 'warn' (list[str]): critical-level warnings
+        - 'orange_warn' (list[str]): caution-level warnings
+        - 'yellow_warn' (list[str]): warning-level messages
+        - 'fyi' (list[str]): informational messages
+        - 'planet_full_mitigation' (bool): True if full planet mitigation
+          applies, allowing 2 fid lights instead of the usual 3
+    """
     from sparkles.checks import get_planet_check_data
     from sparkles.messages import MessagesList
 
@@ -656,6 +693,15 @@ def run_sparkles_planet_checks(proseco_args):
 
 
 def save_proseco_catalogs(path):
+    """
+    Write the accumulated proseco catalogs to a pickle file.
+
+    Pickles the module-level _proseco_catalogs dict (keyed by obsid) to path.
+    Intended to be called at the end of a starcheck run to persist catalogs
+    for downstream use.
+
+    :param path: file path to write the pickle
+    """
     import pickle
 
     with open(path, "wb") as f:

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -659,4 +659,3 @@ def save_proseco_catalogs(path):
 
     with open(path, "wb") as f:
         pickle.dump(_proseco_catalogs, f)
-

--- a/starcheck/utils.py
+++ b/starcheck/utils.py
@@ -587,108 +587,12 @@ def vehicle_filter_backstop(backstop_file, outfile):
     write_backstop(filtered_cmds, outfile)
 
 
-def check_for_planets(date0, duration, att, tol=2.0):
-    import astropy.units as u
-    from chandra_aca.planets import get_planet_angular_sep
-
-    att = Quaternion.Quat(q=att)
-
-    date0 = CxoTime(date0)
-    planets = ("venus", "mars", "jupiter", "saturn")
-    has_planet = dict.fromkeys(planets, False)
-
-    for planet in planets:
-        sep = get_planet_angular_sep(
-            planet,
-            ra=att.ra,
-            dec=att.dec,
-            time=date0 + ([0, 0.5, 1] * u.s) * duration,
-            observer_position="earth",
-        )
-        if np.all(sep > tol + 0.25):
-            continue
-
-        sep = get_planet_angular_sep(
-            planet,
-            ra=att.ra,
-            dec=att.dec,
-            time=date0 + ([0, 0.5, 1] * u.s) * duration,
-            observer_position="chandra",
-        )
-        if np.all(sep > tol):
-            continue
-
-        has_planet[planet] = True
-
-    return has_planet
-
-
-class PlanetPositionTable(Table):
-    @classmethod
-    def empty(cls):
-        return cls({"time": [], "row": [], "col": []})
-
 
 import astropy.units as u
 from cxotime import CxoTimeLike
 from Quaternion import QuatLike
+from chandra_aca.planets import (get_planet_chandra_ccd_position, get_planet_mag_states)
 
-
-def get_planet_position(
-    planet: str,
-    date: CxoTimeLike,
-    duration: float,
-    att: QuatLike,
-) -> PlanetPositionTable:
-    """
-    Get the position of planet on the ACA CCD.
-
-    Parameters
-    ----------
-    planet : str
-        The planet name. Supports
-    date : CxoTimeLike
-        The start date of the observation (acquisition time)
-    duration : float
-        The duration of the observation in seconds.
-    att : Quaternion or Quat-compatible
-        The attitude Quaternion.
-
-    Returns
-    -------
-    PlanetPositionTable
-        A table with columns 'time', 'row', 'col' for the times when Jupiter
-        is on the CCD. If Jupiter is never on the CCD this is a table with zero rows.
-    """
-    date0 = CxoTime(date)
-    att = Quaternion.Quat(att)
-    # dates is a 1-d array with a minimum of 2 points (the end points)
-    dates = CxoTime.linspace(date0, date0 + duration * u.s, step_max=1000 * u.s)
-    times = dates.secs
-
-    from chandra_aca.planets import get_planet_chandra
-    from chandra_aca.transform import eci_to_radec, radec_to_yagzag, yagzag_to_pixels
-
-    eci = get_planet_chandra(planet, times, ephem_source="stk")
-
-    # Convert ECI position to RA, Dec => yag, zag => row, col
-    ra, dec = eci_to_radec(eci)
-    yag, zag = radec_to_yagzag(ra, dec, att)
-    row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
-
-    # Row/col limit in pixels to check for bright object
-    ccd_limit = 512
-
-    # Limit data to entries on the CCD
-    ok = (np.abs(row) <= ccd_limit) & (np.abs(col) <= ccd_limit)
-    out = PlanetPositionTable(
-        {
-            "time": times[ok],
-            "row": row[ok],
-            "col": col[ok],
-        }
-    )
-    return out
 
 
 def get_proseco_catalog(**kw):
@@ -729,19 +633,24 @@ def get_proseco_catalog(**kw):
     if "monitors" in kw:
         args["monitors"] = kw["monitors"]
     aca = get_aca_catalog(**args)
+    # Let's write this out to a pickle file for debugging
+
+    with open(f"aca_debug_{args['obsid']}.pkl", "wb") as f:
+        import pickle
+        pickle.dump(aca, f)
     return aca
 
 
-def run_jupiter_checks(proseco_args):
-    from sparkles.checks import check_run_jupiter_checks
+
+
+def run_sparkles_planet_checks(proseco_args):
+    from sparkles.checks import check_planets
     from sparkles.messages import MessagesList
 
-    # Override the target name to be Jupiter to run the checks
-    proseco_args["target_name"] = "Jupiter"
     aca = get_proseco_catalog(**proseco_args)
     acar = aca.get_review_table()
 
-    msgs = MessagesList(check_run_jupiter_checks(acar))
+    msgs = MessagesList(check_planets(acar))
     return {
         "warn": [w["text"] for w in msgs == "critical"],
         "orange_warn": [w["text"] for w in msgs == "caution"],
@@ -749,52 +658,3 @@ def run_jupiter_checks(proseco_args):
         "fyi": [w["text"] for w in msgs == "info"],
     }
 
-
-def check_bright_objects(proseco_args):
-    has_planet = check_for_planets(
-        proseco_args["date"],
-        proseco_args["duration"],
-        proseco_args["att"],
-        tol=2,
-    )
-
-    if not any(has_planet.values()):
-        return {}
-
-    msgs = collections.defaultdict(list)
-
-    if has_planet["venus"]:
-        msgs["warn"].extend(["Bright object alert: Venus within 2 deg of ACA center\n"])
-
-    for planet in ("mars", "jupiter", "saturn"):
-        if has_planet[planet]:
-            pos = get_planet_position(
-                planet,
-                proseco_args["date"],
-                proseco_args["duration"],
-                proseco_args["att"],
-            )
-
-            if len(pos) == 0:
-                msgs["warn"].extend(
-                    [
-                        f"Bright object alert: {planet.title()} within 2 deg of ACA center, ",
-                        "but not on CCD\n",
-                    ]
-                )
-            else:
-                if planet not in proseco_args["target_name"].lower():
-                    msgs["orange_warn"].extend(
-                        [
-                            f"Bright object alert: {planet.title()} on CCD but not in target name\n"
-                        ]
-                    )
-
-                if planet in ("mars", "saturn"):
-                    msgs["fyi"].extend([f"Bright object: {planet.title()} on CCD\n"])
-
-                if planet == "jupiter":
-                    jmsgs = run_jupiter_checks(proseco_args)
-                    for key in jmsgs:
-                        msgs[key].extend(jmsgs[key])
-    return msgs


### PR DESCRIPTION
## Description

This branch extends starcheck’s planet handling from plot-only visibility to text warnings / real review output.

Before this change, starcheck plots would display planet positions (via chandra_aca plotting support), but starcheck did not run planet checks. With this change, starcheck now runs the sparkles planet checks during processing and emits text messages in the starcheck report:
1. Warning/critical-style messages for planet-related risk conditions
2. Informational statements when planets are detected in the check window
3. Coverage for planets within 2 degrees of pointing and additional checks for objects on-CCD
4. Handles two-fid catalogs with planet-required-full-mitigation

Additional changes (separate from planet warning behavior)
1. processing summary parsing improvement for maneuver matching
This change is only for running old schedules in regression.  For pre-2020 ER-style/non-numeric dot obsid cases, maneuver setup now uses processing-summary content to map dot obsid values to numeric obsids before matching MP_TARGQUAT maneuvers. This makes maneuver association more robust for older loads. (this is largely done so that earlier loads with planets can be successfully run in modern starcheck for testing, but the changes are benign for modern loads).  

2. Debug catalog pickle output
A new command-line option allows saving generated proseco catalogs to a pickle file for debugging/regression analysis workflows.

3. Proseco argument improvements
Starcheck now passes additional context (including duration and target name) into the proseco/sparkles path used for these checks.

##
Requirements
https://github.com/sot/chandra_aca/pull/203
https://github.com/sot/proseco/pull/415
https://github.com/sot/sparkles/pull/229

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
(ska3-latest) jeanconn-kady> env PYTHONPATH=/home/jeanconn/git/obo/chandra_aca:/home/jeanconn/git/obo/proseco:/home/jeanconn/git/obo/sparkles pytest
========================================================= test session starts ==========================================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 19 items                                                                                                                     

starcheck/tests/test_state_checks.py .............                                                                               [ 68%]
starcheck/tests/test_utils.py ......                                                                                             [100%]

========================================================= 19 passed in 17.77s ==========================================================
(ska3-latest) jeanconn-kady> git rev-parse HEAD
b8f8af0be7e878aa69ce3c3f8e782f9f9770fd3e
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Regression testing via a set of weekly schedules with known planets:

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/starcheck/starcheck-planets/combined_diff.txt

I do note that there can be a new hiccup now when running starcheck on historical loads - the agasc supplement in use for proseco differs from the agasc supplement used to build the loads.  This can result in the proseco catalog and the starcheck catalog being out of order. Since starcheck is using proseco/sparkles for these planet checks, the idx can be incorrect.  I don't see an issue for nominal load checking and we can decide if we want to do something like construct custom AGASC_DIR for regression testing in the future.

Another option would be to extend proseco to accept something to enforce catalog order.

Functional testing is in the sparkles PR.
